### PR TITLE
Fix panic in allowed versions

### DIFF
--- a/api/v1alpha1/databaseengine_types.go
+++ b/api/v1alpha1/databaseengine_types.go
@@ -168,8 +168,13 @@ func (c ComponentsMap) GetAllowedVersionsSorted() []string {
 }
 
 // BestVersion returns the best version for the components map.
+// In case no versions are found, it returns an empty string.
 func (c ComponentsMap) BestVersion() string {
 	allowedVersions := c.GetAllowedVersionsSorted()
+	if len(allowedVersions) == 0 {
+		return ""
+	}
+
 	return allowedVersions[0]
 }
 


### PR DESCRIPTION
- In case DBEngine has not been properly initialized we panicked
- The panic came from DBCluster controller
- DBEngine did not have enough time to be initialize