### PR TITLE
EVEREST-324 Fixed scaling for pxc and psmdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.12
+VERSION ?= 0.0.13
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/Makefile
+++ b/Makefile
@@ -309,3 +309,6 @@ DEPLOYDIR = ./deploy
 .PHONY: $(DEPLOYDIR)/bundle.yaml
 $(DEPLOYDIR)/bundle.yaml: manifests kustomize ## Generate deploy/bundle.yaml
 	$(KUSTOMIZE) build config/default -o $(DEPLOYDIR)/bundle.yaml
+
+.PHONY: release
+release:  generate manifests bundle format $(DEPLOYDIR)/bundle.yaml ## Prepare release

--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -197,7 +197,7 @@ type DatabaseClusterSpec struct {
 	// Paused is a flag to stop the cluster
 	Paused bool `json:"paused,omitempty"`
 	// AllowUnsafeConfiguration field used to ensure that the user can create configurations unfit for production use.
-	AllowUnsafeConfiguration bool `json:"unsafeConfiguration,omitempty"`
+	AllowUnsafeConfiguration bool `json:"allowUnsafeConfiguration,omitempty"`
 	// Engine is the database engine specification
 	Engine Engine `json:"engine"`
 	// Proxy is the proxy specification. If not set, an appropriate

--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -97,7 +97,7 @@ type Resources struct {
 type Engine struct {
 	// Type is the engine type
 	Type EngineType `json:"type"`
-	// UnsafeConfiguration field used to ensure bla bla bla
+	// UnsafeConfiguration field used to ensure that the user can create configurations unfit for production use.
 	UnsafeConfiguration bool `json:"unsafeConfiguration,omitempty"`
 	// Version is the engine version
 	Version string `json:"version,omitempty"`

--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -97,6 +97,8 @@ type Resources struct {
 type Engine struct {
 	// Type is the engine type
 	Type EngineType `json:"type"`
+	// UnsafeConfiguration field used to ensure bla bla bla
+	UnsafeConfiguration bool `json:"unsafeConfiguration,omitempty"`
 	// Version is the engine version
 	Version string `json:"version,omitempty"`
 	// Replicas is the number of engine replicas

--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -97,8 +97,6 @@ type Resources struct {
 type Engine struct {
 	// Type is the engine type
 	Type EngineType `json:"type"`
-	// UnsafeConfiguration field used to ensure that the user can create configurations unfit for production use.
-	UnsafeConfiguration bool `json:"unsafeConfiguration,omitempty"`
 	// Version is the engine version
 	Version string `json:"version,omitempty"`
 	// Replicas is the number of engine replicas
@@ -198,6 +196,8 @@ type Monitoring struct {
 type DatabaseClusterSpec struct {
 	// Paused is a flag to stop the cluster
 	Paused bool `json:"paused,omitempty"`
+	// AllowUnsafeConfiguration field used to ensure that the user can create configurations unfit for production use.
+	AllowUnsafeConfiguration bool `json:"unsafeConfiguration,omitempty"`
 	// Engine is the database engine specification
 	Engine Engine `json:"engine"`
 	// Proxy is the proxy specification. If not set, an appropriate

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -103,10 +103,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-09-01T13:01:35Z"
+    createdAt: "2023-09-01T13:57:46Z"
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: everest-operator.v0.0.12
+  name: everest-operator.v0.0.13
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -512,7 +512,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: docker.io/percona/everest-operator:0.0.12
+                image: docker.io/percona/everest-operator:0.0.13
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -606,4 +606,4 @@ spec:
   provider:
     name: Percona
     url: https://percona.com
-  version: 0.0.12
+  version: 0.0.13

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-09-01T13:57:46Z"
+    createdAt: "2023-09-01T14:02:56Z"
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: everest-operator.v0.0.13

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-09-01T11:14:51Z"
+    createdAt: "2023-09-01T13:01:35Z"
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: everest-operator.v0.0.12

--- a/bundle/manifests/everest.percona.com_databaseclusters.yaml
+++ b/bundle/manifests/everest.percona.com_databaseclusters.yaml
@@ -165,10 +165,6 @@ spec:
                   type:
                     description: Type is the engine type
                     type: string
-                  unsafeConfiguration:
-                    description: UnsafeConfiguration field used to ensure bla bla
-                      bla
-                    type: boolean
                   userSecretsName:
                     description: UserSecretsName is the name of the secret containing
                       the user secrets
@@ -299,6 +295,10 @@ spec:
                     - pgbouncer
                     type: string
                 type: object
+              unsafeConfiguration:
+                description: AllowUnsafeConfiguration field used to ensure that the
+                  user can create configurations unfit for production use.
+                type: boolean
             required:
             - engine
             type: object

--- a/bundle/manifests/everest.percona.com_databaseclusters.yaml
+++ b/bundle/manifests/everest.percona.com_databaseclusters.yaml
@@ -54,6 +54,10 @@ spec:
           spec:
             description: DatabaseClusterSpec defines the desired state of DatabaseCluster.
             properties:
+              allowUnsafeConfiguration:
+                description: AllowUnsafeConfiguration field used to ensure that the
+                  user can create configurations unfit for production use.
+                type: boolean
               backup:
                 description: Backup is the backup specification
                 properties:
@@ -295,10 +299,6 @@ spec:
                     - pgbouncer
                     type: string
                 type: object
-              unsafeConfiguration:
-                description: AllowUnsafeConfiguration field used to ensure that the
-                  user can create configurations unfit for production use.
-                type: boolean
             required:
             - engine
             type: object

--- a/bundle/manifests/everest.percona.com_databaseclusters.yaml
+++ b/bundle/manifests/everest.percona.com_databaseclusters.yaml
@@ -165,6 +165,10 @@ spec:
                   type:
                     description: Type is the engine type
                     type: string
+                  unsafeConfiguration:
+                    description: UnsafeConfiguration field used to ensure bla bla
+                      bla
+                    type: boolean
                   userSecretsName:
                     description: UserSecretsName is the name of the secret containing
                       the user secrets

--- a/config/crd/bases/everest.percona.com_databaseclusters.yaml
+++ b/config/crd/bases/everest.percona.com_databaseclusters.yaml
@@ -55,6 +55,10 @@ spec:
           spec:
             description: DatabaseClusterSpec defines the desired state of DatabaseCluster.
             properties:
+              allowUnsafeConfiguration:
+                description: AllowUnsafeConfiguration field used to ensure that the
+                  user can create configurations unfit for production use.
+                type: boolean
               backup:
                 description: Backup is the backup specification
                 properties:
@@ -296,10 +300,6 @@ spec:
                     - pgbouncer
                     type: string
                 type: object
-              unsafeConfiguration:
-                description: AllowUnsafeConfiguration field used to ensure that the
-                  user can create configurations unfit for production use.
-                type: boolean
             required:
             - engine
             type: object

--- a/config/crd/bases/everest.percona.com_databaseclusters.yaml
+++ b/config/crd/bases/everest.percona.com_databaseclusters.yaml
@@ -166,6 +166,10 @@ spec:
                   type:
                     description: Type is the engine type
                     type: string
+                  unsafeConfiguration:
+                    description: UnsafeConfiguration field used to ensure bla bla
+                      bla
+                    type: boolean
                   userSecretsName:
                     description: UserSecretsName is the name of the secret containing
                       the user secrets

--- a/config/crd/bases/everest.percona.com_databaseclusters.yaml
+++ b/config/crd/bases/everest.percona.com_databaseclusters.yaml
@@ -166,10 +166,6 @@ spec:
                   type:
                     description: Type is the engine type
                     type: string
-                  unsafeConfiguration:
-                    description: UnsafeConfiguration field used to ensure bla bla
-                      bla
-                    type: boolean
                   userSecretsName:
                     description: UserSecretsName is the name of the secret containing
                       the user secrets
@@ -300,6 +296,10 @@ spec:
                     - pgbouncer
                     type: string
                 type: object
+              unsafeConfiguration:
+                description: AllowUnsafeConfiguration field used to ensure that the
+                  user can create configurations unfit for production use.
+                type: boolean
             required:
             - engine
             type: object

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: docker.io/percona/everest-operator
-  newTag: 0.0.12
+  newTag: 0.0.13

--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -197,7 +197,7 @@ func (r *DatabaseClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		database.Spec.Engine.Replicas = 3
 	}
 	if database.Spec.Engine.Replicas == 1 {
-		database.Spec.Engine.UnsafeConfiguration = true
+		database.Spec.AllowUnsafeConfiguration = true
 	}
 
 	if database.Spec.Engine.Type == everestv1alpha1.DatabaseEnginePXC {
@@ -505,7 +505,7 @@ func (r *DatabaseClusterReconciler) reconcilePSMDB(ctx context.Context, req ctrl
 		}
 
 		psmdb.Spec.CRVersion = version.ToCRVersion()
-		psmdb.Spec.UnsafeConf = database.Spec.Engine.UnsafeConfiguration
+		psmdb.Spec.UnsafeConf = database.Spec.AllowUnsafeConfiguration
 		psmdb.Spec.Pause = database.Spec.Paused
 
 		if database.Spec.Engine.Version == "" {
@@ -1030,7 +1030,7 @@ func (r *DatabaseClusterReconciler) reconcilePXC(ctx context.Context, req ctrl.R
 		}
 
 		pxc.Spec.CRVersion = version.ToCRVersion()
-		pxc.Spec.AllowUnsafeConfig = database.Spec.Engine.UnsafeConfiguration
+		pxc.Spec.AllowUnsafeConfig = database.Spec.AllowUnsafeConfiguration
 		pxc.Spec.Pause = database.Spec.Paused
 		pxc.Spec.SecretsName = database.Spec.Engine.UserSecretsName
 

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -326,6 +326,9 @@ spec:
           spec:
             description: DatabaseClusterSpec defines the desired state of DatabaseCluster.
             properties:
+              allowUnsafeConfiguration:
+                description: AllowUnsafeConfiguration field used to ensure that the user can create configurations unfit for production use.
+                type: boolean
               backup:
                 description: Backup is the backup specification
                 properties:
@@ -1324,7 +1327,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/percona/everest-operator:0.0.10
+        image: docker.io/percona/everest-operator:0.0.13
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
EVEREST-324

Dropped sharded mongo because it should be done in a different way and we received feedback to have this option in the UI. Until then we do not support sharded mongo instances.
Toggling unsafeConfigurations from true to false and vice versa may lead to unexpected behavior in operator 