### PR TITLE
EVEREST-357 reduce size of the restore name

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -253,7 +253,7 @@ func (r *DatabaseClusterReconciler) reconcileDBRestoreFromDataSource(ctx context
 
 	dbRestore := &everestv1alpha1.DatabaseClusterRestore{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      database.Name + "-datasource",
+			Name:      database.Name,
 			Namespace: database.Namespace,
 		},
 	}


### PR DESCRIPTION
EVEREST-357

Reduce the size of the restore name to avoid exceeding the RFC1123 limit.