### PR TITLE
EVEREST-397 fix PSMDB restore deadlock

### DIFF
--- a/controllers/databaseclusterrestore_controller.go
+++ b/controllers/databaseclusterrestore_controller.go
@@ -65,6 +65,8 @@ type DatabaseClusterRestoreReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
+//
+//nolint:gocognit
 func (r *DatabaseClusterRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("reconciling", "request", req)
@@ -168,7 +170,8 @@ func (r *DatabaseClusterRestoreReconciler) ensureClusterIsReady(ctx context.Cont
 			if err != nil {
 				return err
 			}
-			if cluster.Status.Status == everestv1alpha1.AppStateReady {
+			if cluster.Status.Status == everestv1alpha1.AppStateReady ||
+				cluster.Status.Status == everestv1alpha1.AppStateRestoring {
 				return nil
 			}
 		}


### PR DESCRIPTION
By changing the DB cluster state to "restoring" when a restoration is in progress we introduced a deadlock where the restore isn't able to be updated because it's waiting for the DB to be ready and the DB won't ever be ready while the restore isn't ready. In this commit we also accept the DB restoring state to reconcile the restore CR which removes the deadlock.