### PR TITLE
EVEREST-200 delete SSL secrets

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -130,6 +130,8 @@ timeout server 28800s
 	finalizerDeletePXCPVC           = "delete-pxc-pvc"
 	finalizerDeletePSMDBPVC         = "delete-psmdb-pvc"
 	finalizerDeletePGPVC            = "percona.com/delete-pvc"
+	finalizerDeletePXCSSL           = "delete-ssl"
+	finalizerDeletePGSSL            = "percona.com/delete-ssl"
 )
 
 var operatorDeployment = map[everestv1alpha1.EngineType]string{
@@ -1053,6 +1055,9 @@ func (r *DatabaseClusterReconciler) reconcilePXC(ctx context.Context, req ctrl.R
 		}
 		if !controllerutil.ContainsFinalizer(pxc, finalizerDeletePXCPVC) {
 			controllerutil.AddFinalizer(pxc, finalizerDeletePXCPVC)
+		}
+		if !controllerutil.ContainsFinalizer(pxc, finalizerDeletePXCSSL) {
+			controllerutil.AddFinalizer(pxc, finalizerDeletePXCSSL)
 		}
 		pxc.TypeMeta = metav1.TypeMeta{
 			APIVersion: version.ToAPIVersion(pxcAPIGroup),
@@ -2012,6 +2017,9 @@ func (r *DatabaseClusterReconciler) reconcilePG(ctx context.Context, req ctrl.Re
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, pg, func() error {
 		if !controllerutil.ContainsFinalizer(pg, finalizerDeletePGPVC) {
 			controllerutil.AddFinalizer(pg, finalizerDeletePGPVC)
+		}
+		if !controllerutil.ContainsFinalizer(pg, finalizerDeletePGSSL) {
+			controllerutil.AddFinalizer(pg, finalizerDeletePGSSL)
 		}
 		pg.TypeMeta = metav1.TypeMeta{
 			APIVersion: fmt.Sprintf("%s/v2", pgAPIGroup),

--- a/e2e-tests/tests/core/pg/10-assert.yaml
+++ b/e2e-tests/tests/core/pg/10-assert.yaml
@@ -30,6 +30,7 @@ metadata:
   name: test-pg-cluster
   finalizers:
     - percona.com/delete-pvc
+    - percona.com/delete-ssl
 spec:
   backups:
     pgbackrest:

--- a/e2e-tests/tests/core/pxc/10-assert.yaml
+++ b/e2e-tests/tests/core/pxc/10-assert.yaml
@@ -31,6 +31,7 @@ metadata:
   finalizers:
     - delete-pxc-pods-in-order
     - delete-pxc-pvc
+    - delete-ssl
 spec:
   haproxy:
     enabled: true


### PR DESCRIPTION
EVEREST-200

In the same way that PR #75 added the delete PVC finalizer that ensures the deletion of PVCs as well as the DB connection secrets we shall also add the delete SSL finalizer to delete the auto-generated SSL certs secrets.

We don't need any finalizer for PSMDB because the SSL secrets have an owner reference to the PerconaServerMongoDB CR so they get automatically deleted when the DB cluster is deleted.