### PR TITLE
EVEREST-107 Proper cleanup after each step

### DIFF
--- a/e2e-tests/tests/core/pg/40-delete-cluster.yaml
+++ b/e2e-tests/tests/core/pg/40-delete-cluster.yaml
@@ -5,3 +5,5 @@ commands:
   - command: kubectl -n $NAMESPACE delete db test-pg-cluster
   - command: kubectl patch postgresclusters test-pg-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
     ignoreFailure: true
+  - command: kubectl patch pg test-pg-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/core/pg/40-delete-cluster.yaml
+++ b/e2e-tests/tests/core/pg/40-delete-cluster.yaml
@@ -4,3 +4,4 @@ timeout: 10
 commands:
   - command: kubectl -n $NAMESPACE delete db test-pg-cluster
   - command: kubectl patch postgresclusters test-pg-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/core/pg/40-delete-cluster.yaml
+++ b/e2e-tests/tests/core/pg/40-delete-cluster.yaml
@@ -1,7 +1,6 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 timeout: 10
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
-  name: test-pg-cluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db test-pg-cluster
+  - command: kubectl patch postgresclusters test-pg-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/core/pg/41-wait-deletion.yaml
+++ b/e2e-tests/tests/core/pg/41-wait-deletion.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+commands:
+  - command:  kubectl wait --for=delete postgres/test-pg-cluster -n $NAMESPACE --timeout=120s

--- a/e2e-tests/tests/core/pg/41-wait-deletion.yaml
+++ b/e2e-tests/tests/core/pg/41-wait-deletion.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 commands:
-  - command:  kubectl wait --for=delete postgres/test-pg-cluster -n $NAMESPACE --timeout=120s
+  - command:  kubectl wait --for=delete postgresclusters/test-pg-cluster -n $NAMESPACE --timeout=120s

--- a/e2e-tests/tests/core/pg/90-delete-clusters.yaml
+++ b/e2e-tests/tests/core/pg/90-delete-clusters.yaml
@@ -4,3 +4,6 @@ commands:
   - command: kubectl -n $NAMESPACE delete db test-single-node
   - command: kubectl patch postgresclusters test-single-node -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
     ignoreFailure: true
+  - command: kubectl -n $NAMESPACE delete db test-pg-cluster
+  - command: kubectl patch postgresclusters test-pg-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/core/pg/90-delete-clusters.yaml
+++ b/e2e-tests/tests/core/pg/90-delete-clusters.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db test-single-node
+  - command: kubectl patch postgresclusters test-single-node -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/core/pg/90-delete-clusters.yaml
+++ b/e2e-tests/tests/core/pg/90-delete-clusters.yaml
@@ -3,3 +3,4 @@ kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-single-node
   - command: kubectl patch postgresclusters test-single-node -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/core/psmdb/40-delete-clusters.yaml
+++ b/e2e-tests/tests/core/psmdb/40-delete-clusters.yaml
@@ -2,5 +2,6 @@ apiVersion: kuttl.dev/v1
 kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
+  - command: kubectl -n $NAMESPACE delete secret everest-secrets-test-psmdb-cluster
   - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
     ignoreFailure: true

--- a/e2e-tests/tests/core/psmdb/40-delete-clusters.yaml
+++ b/e2e-tests/tests/core/psmdb/40-delete-clusters.yaml
@@ -3,5 +3,6 @@ kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
   - command: kubectl -n $NAMESPACE delete secret everest-secrets-test-psmdb-cluster
+    ignoreFailure: true
   - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
     ignoreFailure: true

--- a/e2e-tests/tests/core/psmdb/40-delete-clusters.yaml
+++ b/e2e-tests/tests/core/psmdb/40-delete-clusters.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
-timeout: 10
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
+  - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/core/psmdb/40-delete-clusters.yaml
+++ b/e2e-tests/tests/core/psmdb/40-delete-clusters.yaml
@@ -3,3 +3,4 @@ kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
   - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/core/psmdb/41-wait-deletion.yaml
+++ b/e2e-tests/tests/core/psmdb/41-wait-deletion.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+commands:
+  - command:  kubectl wait --for=delete psmdb/test-psmdb-cluster -n $NAMESPACE --timeout=120s

--- a/e2e-tests/tests/core/psmdb/50-assert.yaml
+++ b/e2e-tests/tests/core/psmdb/50-assert.yaml
@@ -5,7 +5,7 @@ timeout: 300
 apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseCluster
 metadata:
-  name: test-psmdb-cluster
+  name: single-node
 spec:
   allowUnsafeConfiguration: true
   engine:
@@ -32,7 +32,7 @@ status:
 apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB
 metadata:
-  name: test-psmdb-cluster
+  name: single-node
 spec:
   crVersion: 1.14.0
   allowUnsafeConfigurations: true

--- a/e2e-tests/tests/core/psmdb/50-create-single-node-cluster.yaml
+++ b/e2e-tests/tests/core/psmdb/50-create-single-node-cluster.yaml
@@ -4,7 +4,7 @@ kind: TestStep
 apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseCluster
 metadata:
-  name: test-psmdb-cluster
+  name: single-node
 spec:
   engine:
     type: psmdb

--- a/e2e-tests/tests/core/psmdb/60-assert.yaml
+++ b/e2e-tests/tests/core/psmdb/60-assert.yaml
@@ -5,7 +5,7 @@ timeout: 300
 apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseCluster
 metadata:
-  name: test-psmdb-cluster
+  name: single-node
 spec:
   allowUnsafeConfiguration: true
   engine:
@@ -32,7 +32,7 @@ status:
 apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB
 metadata:
-  name: test-psmdb-cluster
+  name: single-node
 spec:
   crVersion: 1.14.0
   allowUnsafeConfigurations: true

--- a/e2e-tests/tests/core/psmdb/60-scale-cluster.yaml
+++ b/e2e-tests/tests/core/psmdb/60-scale-cluster.yaml
@@ -4,7 +4,7 @@ kind: TestStep
 apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseCluster
 metadata:
-  name: test-psmdb-cluster
+  name: single-node
 spec:
   allowUnsafeConfiguration: true
   engine:

--- a/e2e-tests/tests/core/psmdb/97-delete-clusters.yaml
+++ b/e2e-tests/tests/core/psmdb/97-delete-clusters.yaml
@@ -2,6 +2,6 @@ apiVersion: kuttl.dev/v1
 kind: TestStep
 timeout: 10
 commands:
-  - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
-  - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+  - command: kubectl -n $NAMESPACE delete db single-node
+  - command: kubectl patch psmdb single-node -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
     ignoreFailure: true

--- a/e2e-tests/tests/core/psmdb/97-delete-clusters.yaml
+++ b/e2e-tests/tests/core/psmdb/97-delete-clusters.yaml
@@ -4,3 +4,4 @@ timeout: 10
 commands:
   - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
   - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/core/psmdb/97-delete-clusters.yaml
+++ b/e2e-tests/tests/core/psmdb/97-delete-clusters.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 timeout: 10
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
+  - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/core/pxc/40-delete-cluster.yaml
+++ b/e2e-tests/tests/core/pxc/40-delete-cluster.yaml
@@ -1,7 +1,6 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 timeout: 10
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
-  name: test-pxc-cluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
+  - command: kubectl patch pxc test-pxc-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/core/pxc/40-delete-cluster.yaml
+++ b/e2e-tests/tests/core/pxc/40-delete-cluster.yaml
@@ -4,3 +4,4 @@ timeout: 10
 commands:
   - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
   - command: kubectl patch pxc test-pxc-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/core/pxc/41-wait-deletion.yaml
+++ b/e2e-tests/tests/core/pxc/41-wait-deletion.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+commands:
+  - command:  kubectl wait --for=delete pxc/test-pxc-cluster -n $NAMESPACE --timeout=120s

--- a/e2e-tests/tests/core/pxc/97-delete-cluster.yaml
+++ b/e2e-tests/tests/core/pxc/97-delete-cluster.yaml
@@ -3,3 +3,4 @@ kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
   - command: kubectl patch pxc test-pxc-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/core/pxc/97-delete-cluster.yaml
+++ b/e2e-tests/tests/core/pxc/97-delete-cluster.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
+  - command: kubectl patch pxc test-pxc-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/features/dbbackup_pg/90-delete-clusters.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/90-delete-clusters.yaml
@@ -3,3 +3,4 @@ kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-pg-cluster
   - command: kubectl patch postgresclusters test-pg-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/features/dbbackup_pg/90-delete-clusters.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/90-delete-clusters.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db test-pg-cluster
+  - command: kubectl patch postgresclusters test-pg-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/features/dbbackup_psmdb/90-delete-cluster.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/90-delete-cluster.yaml
@@ -1,7 +1,5 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
-timeout: 10
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
-  name: test-psmdb-cluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
+  - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/features/dbbackup_psmdb/90-delete-cluster.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/90-delete-cluster.yaml
@@ -3,3 +3,4 @@ kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
   - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/features/dbbackup_pxc/90-delete-cluster.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/90-delete-cluster.yaml
@@ -3,3 +3,4 @@ kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
   - command: kubectl patch pxc test-pxc-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/features/dbbackup_pxc/90-delete-cluster.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/90-delete-cluster.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
+  - command: kubectl patch pxc test-pxc-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/features/monitoringconfig_pg/96-delete-clusters.yaml
+++ b/e2e-tests/tests/features/monitoringconfig_pg/96-delete-clusters.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db pg-mc
+  - command: kubectl patch postgresclusters pg-mc -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/features/monitoringconfig_pg/96-delete-clusters.yaml
+++ b/e2e-tests/tests/features/monitoringconfig_pg/96-delete-clusters.yaml
@@ -3,3 +3,4 @@ kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db pg-mc
   - command: kubectl patch postgresclusters pg-mc -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/features/monitoringconfig_psmdb/96-delete-clusters.yaml
+++ b/e2e-tests/tests/features/monitoringconfig_psmdb/96-delete-clusters.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db mongo-mc
+  - command: kubectl patch psmdb mongo-mc -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/features/monitoringconfig_psmdb/96-delete-clusters.yaml
+++ b/e2e-tests/tests/features/monitoringconfig_psmdb/96-delete-clusters.yaml
@@ -3,3 +3,4 @@ kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db mongo-mc
   - command: kubectl patch psmdb mongo-mc -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/features/monitoringconfig_pxc/96-delete-clusters.yaml
+++ b/e2e-tests/tests/features/monitoringconfig_pxc/96-delete-clusters.yaml
@@ -3,3 +3,4 @@ kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db pxc-mc
   - command: kubectl patch pxc pxc-mc -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/features/monitoringconfig_pxc/96-delete-clusters.yaml
+++ b/e2e-tests/tests/features/monitoringconfig_pxc/96-delete-clusters.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db pxc-mc
+  - command: kubectl patch pxc pxc-mc -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/features/scheduled_backups/04-cleanup.yaml
+++ b/e2e-tests/tests/features/scheduled_backups/04-cleanup.yaml
@@ -3,5 +3,7 @@ kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
   - command: kubectl patch pxc test-pxc-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true
   - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
   - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/features/scheduled_backups/04-cleanup.yaml
+++ b/e2e-tests/tests/features/scheduled_backups/04-cleanup.yaml
@@ -1,5 +1,7 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
+  - command: kubectl patch pxc test-pxc-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+  - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
+  - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge

--- a/e2e-tests/tests/features/templates/98-delete-clusters.yaml
+++ b/e2e-tests/tests/features/templates/98-delete-clusters.yaml
@@ -3,3 +3,4 @@ kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
   - command: kubectl patch pxc test-pxc-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true

--- a/e2e-tests/tests/features/templates/98-delete-clusters.yaml
+++ b/e2e-tests/tests/features/templates/98-delete-clusters.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
-delete:
-- apiVersion: everest.percona.com/v1alpha1
-  kind: DatabaseCluster
+commands:
+  - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
+  - command: kubectl patch pxc test-pxc-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-107

*Short explanation of the problem.*

Once we enabled a manual cleanup step and used the `skipDelete` option for Kuttl sometimes it ended up with leftover pods running inside the cluster which may lead to flaky tests because of a lack of compute resources.



**Related pull requests**

- [link]

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

Having proper cleanup and deletion of a database cluster on each step solves this issue some leftovers may be there but it makes everything more stable 

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [x] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
