### PR TITLE
EVEREST-458 Set labels for the manager for faster search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.22
+VERSION ?= 0.3.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -103,10 +103,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-09-21T09:19:50Z"
+    createdAt: "2023-10-04T14:43:09Z"
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: everest-operator.v0.0.22
+  name: everest-operator.v0.3.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -459,6 +459,10 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
+                app.kubernetes.io/component: operator
+                app.kubernetes.io/instance: everest-operator
+                app.kubernetes.io/name: everest-operator
+                app.kubernetes.io/part-of: everest-operator
                 control-plane: controller-manager
             spec:
               affinity:
@@ -512,7 +516,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: docker.io/percona/everest-operator:0.0.22
+                image: docker.io/percona/everest-operator:0.3.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -606,4 +610,4 @@ spec:
   provider:
     name: Percona
     url: https://percona.com
-  version: 0.0.22
+  version: 0.3.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: docker.io/percona/everest-operator
-  newTag: 0.0.22
+  newTag: 0.3.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,10 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: everest-operator
+        app.kubernetes.io/name: everest-operator
+        app.kubernetes.io/part-of: everest-operator
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -1281,6 +1281,10 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: everest-operator
+        app.kubernetes.io/name: everest-operator
+        app.kubernetes.io/part-of: everest-operator
         control-plane: controller-manager
     spec:
       affinity:
@@ -1334,7 +1338,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/percona/everest-operator:0.0.22
+        image: docker.io/percona/everest-operator:0.3.1
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-458

*Short explanation of the problem.*

The default labels are not enough to be sure and list pods created by deployment efficiently 

**Solution:**
*Short explanation of the solution we are providing with this PR.*

Added additional labels that we can use to query k8s API for getting the pod of the everest operator

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
