### PR TITLE
EVEREST-470 Set default resources for backup/proxy pods

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -1909,6 +1909,7 @@ func (r *DatabaseClusterReconciler) genPGDataSourceSpec(ctx context.Context, dat
 				"--type=immediate",
 				"--set=" + backupBaseName,
 			},
+			// XXX: Remove this once templates will be available
 			Resources: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("128Mi"),
@@ -2917,6 +2918,7 @@ func (r *DatabaseClusterReconciler) defaultPGSpec() *pgv2.PerconaPGClusterSpec {
 		Proxy: &pgv2.PGProxySpec{
 			PGBouncer: &pgv2.PGBouncerSpec{
 				Resources: corev1.ResourceRequirements{
+					// XXX: Remove this once templates will be available
 					Limits: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("128Mi"),
 						corev1.ResourceCPU:    resource.MustParse("200m"),
@@ -2967,6 +2969,7 @@ func (r *DatabaseClusterReconciler) defaultPXCSpec() *pxcv1.PerconaXtraDBCluster
 					TopologyKey: pointer.ToString(pxcv1.AffinityTopologyKeyOff),
 				},
 				Resources: corev1.ResourceRequirements{
+					// XXX: Remove this once templates will be available
 					Limits: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("1G"),
 						corev1.ResourceCPU:    resource.MustParse("600m"),

--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -297,6 +297,14 @@ func (r *DatabaseClusterReconciler) genPSMDBBackupSpec(
 	psmdbBackupSpec := psmdbv1.BackupSpec{
 		Enabled: true,
 		Image:   backupVersion.ImagePath,
+
+		// XXX: Remove this once templates will be available
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("0.5G"),
+				corev1.ResourceCPU:    resource.MustParse("300m"),
+			},
+		},
 	}
 
 	storages := make(map[string]psmdbv1.BackupStorageSpec)
@@ -905,6 +913,13 @@ func (r *DatabaseClusterReconciler) genPXCBackupSpec(
 				CredentialsSecret: backupStorage.Spec.CredentialsSecretName,
 				Region:            backupStorage.Spec.Region,
 				EndpointURL:       backupStorage.Spec.EndpointURL,
+			}
+			// XXX: Remove this once templates will be available
+			storages[backup.Spec.BackupStorageName].Resources = corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1G"),
+					corev1.ResourceCPU:    resource.MustParse("600m"),
+				},
 			}
 		default:
 			return nil, fmt.Errorf("unsupported backup storage type %s for %s", backupStorage.Spec.Type, backupStorage.Name)
@@ -1893,6 +1908,12 @@ func (r *DatabaseClusterReconciler) genPGDataSourceSpec(ctx context.Context, dat
 			Options: []string{
 				"--type=immediate",
 				"--set=" + backupBaseName,
+			},
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("128Mi"),
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+				},
 			},
 		},
 	}
@@ -2896,7 +2917,10 @@ func (r *DatabaseClusterReconciler) defaultPGSpec() *pgv2.PerconaPGClusterSpec {
 		Proxy: &pgv2.PGProxySpec{
 			PGBouncer: &pgv2.PGBouncerSpec{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{},
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+					},
 				},
 			},
 		},
@@ -2956,7 +2980,10 @@ func (r *DatabaseClusterReconciler) defaultPXCSpec() *pxcv1.PerconaXtraDBCluster
 				TopologyKey: pointer.ToString(pxcv1.AffinityTopologyKeyOff),
 			},
 			Resources: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1G"),
+					corev1.ResourceCPU:    resource.MustParse("600m"),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-470

*Short explanation of the problem.*
PXC backup container uses resources, but we do not set them . We need to set resources for backup as well.

**Solution:**
*Short explanation of the solution we are providing with this PR.*

Since @hors reported the issue and had a discussion with him about this as the first solution. The operator adopted the default resources provided by operators in cr.yaml file. Yet, we should revisit this once we start working on templates

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
