### PR TITLE
EVEREST-524 Removed custom configuration for HAProxy

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -107,10 +107,6 @@ wsrep_trx_fragment_size=3670016
 	pxcMinimalConfigurationTemplate = `[mysqld]
 wsrep_provider_options="gcache.size=%s"
 `
-	haProxyDefaultConfigurationTemplate = `timeout client 28800s
-timeout connect 100500
-timeout server 28800s
-`
 	psmdbDefaultConfigurationTemplate = `
       operationProfiling:
         mode: slowOp
@@ -1046,9 +1042,6 @@ func (r *DatabaseClusterReconciler) reconcilePXC(ctx context.Context, req ctrl.R
 
 	if database.Spec.Proxy.Type == "" {
 		database.Spec.Proxy.Type = everestv1alpha1.ProxyTypeHAProxy
-	}
-	if database.Spec.Proxy.Type == everestv1alpha1.ProxyTypeHAProxy && database.Spec.Proxy.Config == "" {
-		database.Spec.Proxy.Config = haProxyDefaultConfigurationTemplate
 	}
 	if err := r.Update(ctx, database); err != nil {
 		return err


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-524

*Short explanation of the problem.*
The operator uses the wrong format of the HAProxy config. It's required to pass the whole HAProxy config for the configuration field. You can see the example in the [documentation](https://docs.percona.com/percona-operator-for-mysql/pxc/haproxy-conf.html#passing-custom-configuration-options-to-haproxy)

Also, PXC operator have these parameters as a [new default](https://github.com/percona/percona-docker/commit/deb1e6f03d42cccf4d2e15f1880a1d5a13d0c194) so these options are not needed anymore


**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
