### PR TITLE
EVEREST-568 fix EKS external access LB annotation

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -128,8 +128,7 @@ var (
 	maxUnavailable       = intstr.FromInt(1)
 	exposeAnnotationsMap = map[ClusterType]map[string]string{
 		ClusterTypeEKS: {
-			"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
-			"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "IP",
+			"service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
 		},
 	}
 	memorySmallSize  = resource.MustParse("2G")


### PR DESCRIPTION
**Fix EKS external access LB annotation**
---
**Problem:**
EVEREST-568

It fails to get an external IP for the load balancer service in EKS.

**Related pull requests**

- #126

**Cause:**
We were setting annotations that only apply to the new LB controller add-on. When this add-on isn't installed in the cluster the annotations are not accepted and a IP is not assigned.

**Solution:**
Set NLB but use the legacy controller's annotation. Chetan and Slava confirmed this is the way to go.
Tested it on EKS and it successfully gets an external IP from the load balancer.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~
