### PR TITLE
EVEREST-532 fix mongo scheduled backups

### DIFF
--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-10-13T07:32:32Z"
+    createdAt: "2023-10-24T13:04:52Z"
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: everest-operator.v0.3.3-dev1

--- a/bundle/manifests/everest.percona.com_backupstorages.yaml
+++ b/bundle/manifests/everest.percona.com_backupstorages.yaml
@@ -48,16 +48,14 @@ spec:
                 description: Region is a region where the bucket is located.
                 type: string
               type:
-                description: Type is a type of backup storage. Currently only S3 is
-                  supported.
+                description: Type is a type of backup storage.
                 enum:
                 - s3
+                - azure
                 type: string
             required:
             - bucket
             - credentialsSecretName
-            - endpointURL
-            - region
             - type
             type: object
           status:

--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -399,11 +399,11 @@ func (r *DatabaseClusterBackupReconciler) tryCreatePSMDB(ctx context.Context, ob
 		return err
 	}
 
-	backup.Spec.DBClusterName = psmdbBackup.Spec.PSMDBCluster
+	backup.Spec.DBClusterName = psmdbBackup.Spec.ClusterName
 	backup.Spec.BackupStorageName = psmdbBackup.Spec.StorageName
 
 	backup.ObjectMeta.Labels = map[string]string{
-		databaseClusterNameLabel: psmdbBackup.Spec.PSMDBCluster,
+		databaseClusterNameLabel: psmdbBackup.Spec.ClusterName,
 		fmt.Sprintf(backupStorageNameLabelTmpl, psmdbBackup.Spec.StorageName): backupStorageLabelValue,
 	}
 	backup.ObjectMeta.SetOwnerReferences([]metav1.OwnerReference{{
@@ -543,7 +543,7 @@ func (r *DatabaseClusterBackupReconciler) reconcilePSMDB(ctx context.Context, ba
 			APIVersion: psmdbAPIVersion,
 			Kind:       psmdbBackupKind,
 		}
-		psmdbCR.Spec.PSMDBCluster = backup.Spec.DBClusterName
+		psmdbCR.Spec.ClusterName = backup.Spec.DBClusterName
 		psmdbCR.Spec.StorageName = backup.Spec.BackupStorageName
 
 		psmdbCR.SetOwnerReferences([]metav1.OwnerReference{{

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -56,15 +56,14 @@ spec:
                 description: Region is a region where the bucket is located.
                 type: string
               type:
-                description: Type is a type of backup storage. Currently only S3 is supported.
+                description: Type is a type of backup storage.
                 enum:
                 - s3
+                - azure
                 type: string
             required:
             - bucket
             - credentialsSecretName
-            - endpointURL
-            - region
             - type
             type: object
           status:

--- a/e2e-tests/tests/features/dbbackup_psmdb/20-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/20-assert.yaml
@@ -28,7 +28,7 @@ metadata:
       name: test-db-backup
 spec:
   storageName: test-storage
-  psmdbCluster: test-psmdb-cluster
+  clusterName: test-psmdb-cluster
 ---
 apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDBBackup
@@ -40,7 +40,7 @@ metadata:
       name: test-db-backup-azure
 spec:
   storageName: test-storage-azure
-  psmdbCluster: test-psmdb-cluster
+  clusterName: test-psmdb-cluster
 ---
 apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB

--- a/e2e-tests/tests/features/dbbackup_psmdb/50-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/50-assert.yaml
@@ -20,7 +20,7 @@ metadata:
       name: test-db-backup
 spec:
   storageName: test-storage
-  psmdbCluster: test-psmdb-cluster
+  clusterName: test-psmdb-cluster
 ---
 apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB

--- a/e2e-tests/tests/features/dbbackup_psmdb/70-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/70-assert.yaml
@@ -27,4 +27,4 @@ metadata:
       name: a-scheduled-backup
 spec:
   storageName: test-storage-scheduled
-  psmdbCluster: test-psmdb-cluster
+  clusterName: test-psmdb-cluster

--- a/e2e-tests/tests/features/dbbackup_psmdb/70-scheduled-backup.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/70-scheduled-backup.yaml
@@ -8,4 +8,4 @@ metadata:
   name: a-scheduled-backup
 spec:
   storageName: test-storage-scheduled
-  psmdbCluster: test-psmdb-cluster
+  clusterName: test-psmdb-cluster


### PR DESCRIPTION
**Fix mongo scheduled backups**
---
**Problem:**
EVEREST-532

MongoDB scheduled backups didn't show the cluster name and thus weren't being properly reconciled. 

**Related pull requests**

- #115

**Cause:**
In psmdb operator v1.15.0 the PSMDBCluster field is no longer being filled.

**Solution:**
Move to the new ClusterName field instead of PSMDBCluster.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~
