### PR TITLE
EVEREST-584 Fix PXC being stuck on pause after restore

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -1068,7 +1068,8 @@ func (r *DatabaseClusterReconciler) reconcilePXC(ctx context.Context, req ctrl.R
 			case everestv1alpha1.RestoreState(pxcv1.RestorePITR):
 				jobRunning = true
 			default:
-				jobRunning = false
+				// The jobRunning flag should be sticky if a restore is in a
+				// running state so we don't want to set it to false here.
 			}
 		}
 		if jobRunning {


### PR DESCRIPTION
**EVEREST-584 Fix PXC being stuck on pause after restore**
---
**Problem:**
EVEREST-584

PXC DB is suck on pause after restore.

**Cause:**
If any restore job is running then the DB paused spec must match the PXC pause spec. 
Previously, we were only considering the state of the last restore job in the list. If that last restore had already finished we wouldn't update the DB pause spec with the PXC pause spec.

**Solution:**
We need to make sure that any restore job for that given DB is considered when evaluating if a restore job is running.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~
