### PR TITLE
EVEREST-587: wait for db before restore

### DIFF
--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-11-06T08:48:43Z"
+    createdAt: "2023-11-06T10:55:35Z"
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: everest-operator.v0.4.0

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-10-24T13:04:52Z"
+    createdAt: "2023-11-06T08:48:43Z"
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: everest-operator.v0.4.0

--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -663,7 +663,7 @@ func (r *DatabaseClusterReconciler) reconcilePSMDB(ctx context.Context, req ctrl
 		return err
 	}
 
-	if database.Spec.DataSource != nil {
+	if database.Spec.DataSource != nil && database.Status.Status == everestv1alpha1.AppStateReady {
 		err = r.reconcileDBRestoreFromDataSource(ctx, database)
 		if err != nil {
 			return err
@@ -1270,7 +1270,7 @@ func (r *DatabaseClusterReconciler) reconcilePXC(ctx context.Context, req ctrl.R
 		return err
 	}
 
-	if database.Spec.DataSource != nil {
+	if database.Spec.DataSource != nil && database.Status.Status == everestv1alpha1.AppStateReady {
 		err = r.reconcileDBRestoreFromDataSource(ctx, database)
 		if err != nil {
 			return err


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-587

We did not wait for DB before initiating a restore.

**Cause:**
DB was not ready and the restore failed.

**Solution:**
Wait for DB before restore

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
