### PR TITLE
EVEREST-636 increase PBM memory limit

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -298,7 +298,7 @@ func (r *DatabaseClusterReconciler) genPSMDBBackupSpec(
 		// XXX: Remove this once templates will be available
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("0.5G"),
+				corev1.ResourceMemory: resource.MustParse("1G"),
 				corev1.ResourceCPU:    resource.MustParse("300m"),
 			},
 		},


### PR DESCRIPTION
**EVEREST-636 increase PBM memory limit**
---
**Problem:**
EVEREST-636

PSMDB backup hangs due to lack of memory.

**Cause:**
PBM has bug that causes the backup to hang due to lack of memory.

**Solution:**
Ultimately, this is a PBM issue but from the everest side we try to avoid it by increasing the memory limit.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~
