### PR TITLE
EVEREST-682: copy credentials during db provisioning

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -208,6 +208,13 @@ func (r *DatabaseClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
+	if database.Spec.DataSource != nil && database.Spec.DataSource.DBClusterBackupName != "" {
+		// We don't handle database.Spec.DataSource.BackupSource in operator
+		if err := r.copyCredentialsFromDBBackup(ctx, database.Spec.DataSource.DBClusterBackupName, database); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	if database.Spec.Engine.Type == everestv1alpha1.DatabaseEnginePXC {
 		err := r.reconcilePXC(ctx, req, database)
 		return reconcile.Result{}, err
@@ -224,6 +231,60 @@ func (r *DatabaseClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
+}
+
+// copyCredentialsFromDBBackup copies credentials from an old DB to the new DB about to be
+// provisioned by providing a DB Backup name of the old DB.
+func (r *DatabaseClusterReconciler) copyCredentialsFromDBBackup(
+	ctx context.Context, dbBackupName string, db *everestv1alpha1.DatabaseCluster,
+) error {
+	logger := log.FromContext(ctx)
+
+	dbb := &everestv1alpha1.DatabaseClusterBackup{}
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      dbBackupName,
+		Namespace: db.Namespace,
+	}, dbb)
+	if err != nil {
+		return errors.Join(err, errors.New("could not get DB backup to copy credentials from old DB cluster"))
+	}
+
+	newSecretName := fmt.Sprintf("everest-secrets-%s", db.Name)
+	newSecret := &corev1.Secret{}
+	err = r.Get(ctx, types.NamespacedName{
+		Name:      newSecretName,
+		Namespace: db.Namespace,
+	}, newSecret)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return errors.Join(err, errors.New("could not get secret to copy credentials from old DB cluster"))
+	}
+
+	if err == nil {
+		logger.Info(fmt.Sprintf("Secret %s already exists. Skipping secret copy during provisioning", newSecretName))
+		return nil
+	}
+
+	prevSecretName := fmt.Sprintf("everest-secrets-%s", dbb.Spec.DBClusterName)
+	secret := &corev1.Secret{}
+	err = r.Get(ctx, types.NamespacedName{
+		Name:      prevSecretName,
+		Namespace: db.Namespace,
+	}, secret)
+	if err != nil {
+		return errors.Join(err, errors.New("could not get secret to copy credentials from old DB cluster"))
+	}
+
+	secret.ObjectMeta = metav1.ObjectMeta{
+		Name:      newSecretName,
+		Namespace: secret.Namespace,
+	}
+	if err := r.createOrUpdate(ctx, secret, false); err != nil {
+		return errors.Join(err, errors.New("could not create new secret to copy credentials from old DB cluster"))
+	}
+
+	logger.Info(fmt.Sprintf("Copied secret %s to %s", prevSecretName, newSecretName))
+
+	return nil
 }
 
 func (r *DatabaseClusterReconciler) getClusterType(ctx context.Context) (ClusterType, error) {
@@ -2128,6 +2189,7 @@ func (r *DatabaseClusterReconciler) genPGDataSourceSpec(ctx context.Context, dat
 
 	var backupBaseName string
 	var backupStorageName string
+	var dest string
 	if database.Spec.DataSource.DBClusterBackupName != "" {
 		dbClusterBackup := &everestv1alpha1.DatabaseClusterBackup{}
 		err := r.Get(ctx, types.NamespacedName{Name: database.Spec.DataSource.DBClusterBackupName, Namespace: database.Namespace}, dbClusterBackup)
@@ -2141,6 +2203,7 @@ func (r *DatabaseClusterReconciler) genPGDataSourceSpec(ctx context.Context, dat
 
 		backupBaseName = filepath.Base(*dbClusterBackup.Status.Destination)
 		backupStorageName = dbClusterBackup.Spec.BackupStorageName
+		dest = *dbClusterBackup.Status.Destination
 	}
 
 	if database.Spec.DataSource.BackupSource != nil {
@@ -2148,11 +2211,40 @@ func (r *DatabaseClusterReconciler) genPGDataSourceSpec(ctx context.Context, dat
 		backupStorageName = database.Spec.DataSource.BackupSource.BackupStorageName
 	}
 
+	backupStorage := &everestv1alpha1.BackupStorage{}
+	err := r.Get(ctx, types.NamespacedName{Name: backupStorageName, Namespace: r.defaultNamespace}, backupStorage)
+	if err != nil {
+		return nil, errors.Join(err, fmt.Errorf("failed to get backup storage %s", backupStorageName))
+	}
+	if database.Namespace != r.defaultNamespace {
+		if err := r.reconcileBackupStorageSecret(ctx, backupStorage, database); err != nil {
+			return nil, err
+		}
+	}
+
+	if dest == "" {
+		dest = "/" + backupStoragePrefix(database)
+	} else {
+		// Extract the relevant prefix from the backup destination
+		switch backupStorage.Spec.Type {
+		case everestv1alpha1.BackupStorageTypeS3:
+			dest = strings.TrimPrefix(dest, "s3://")
+		case everestv1alpha1.BackupStorageTypeAzure:
+			dest = strings.TrimPrefix(dest, "azure://")
+		}
+
+		dest = strings.TrimPrefix(dest, backupStorage.Spec.Bucket)
+		dest = strings.TrimLeft(dest, "/")
+		prefix := backupStoragePrefix(database)
+		prefixCount := len(strings.Split(prefix, "/"))
+		dest = "/" + strings.Join(strings.SplitN(dest, "/", prefixCount+1)[0:prefixCount], "/")
+	}
+
 	repoName := "repo1"
 	pgDataSource := &crunchyv1beta1.DataSource{
 		PGBackRest: &crunchyv1beta1.PGBackRestDataSource{
 			Global: map[string]string{
-				fmt.Sprintf(pgBackRestPathTmpl, repoName): "/" + backupStoragePrefix(database),
+				fmt.Sprintf(pgBackRestPathTmpl, repoName): dest,
 			},
 			Stanza: "db",
 			Options: []string{
@@ -2167,17 +2259,6 @@ func (r *DatabaseClusterReconciler) genPGDataSourceSpec(ctx context.Context, dat
 				},
 			},
 		},
-	}
-
-	backupStorage := &everestv1alpha1.BackupStorage{}
-	err := r.Get(ctx, types.NamespacedName{Name: backupStorageName, Namespace: r.defaultNamespace}, backupStorage)
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("failed to get backup storage %s", backupStorageName))
-	}
-	if database.Namespace != r.defaultNamespace {
-		if err := r.reconcileBackupStorageSecret(ctx, backupStorage, database); err != nil {
-			return nil, err
-		}
 	}
 
 	switch backupStorage.Spec.Type {

--- a/e2e-tests/tests/features/dbbackup_pg/25-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/25-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuttl.dev/v1
+kind: TestAssert
+timeout: 400
+---
+apiVersion: everest.percona.com/v1alpha1
+kind: DatabaseCluster
+metadata:
+  name: test-pg-source
+status:
+  status: ready
+---
+apiVersion: pgv2.percona.com/v2
+kind: PerconaPGCluster
+metadata:
+  name: test-pg-source
+status:
+  state: ready

--- a/e2e-tests/tests/features/dbbackup_pg/25-pg-cluster-datasource.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/25-pg-cluster-datasource.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+---
+apiVersion: everest.percona.com/v1alpha1
+kind: DatabaseCluster
+metadata:
+  name: test-pg-source
+spec:
+  dataSource:
+    dbClusterBackupName: test-db-backup
+  engine:
+    type: postgresql
+    replicas: 1
+    storage:
+      size: 1G
+  proxy:
+    type: pgbouncer
+    replicas: 1

--- a/e2e-tests/tests/features/dbbackup_pg/90-delete-clusters.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/90-delete-clusters.yaml
@@ -2,7 +2,10 @@ apiVersion: kuttl.dev/v1
 kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-pg-cluster
+  - command: kubectl -n $NAMESPACE delete db test-pg-source
   - command: kubectl patch backupstorage test-storage-scheduled -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
     ignoreFailure: true
   - command: kubectl patch postgresclusters test-pg-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true
+  - command: kubectl patch postgresclusters test-pg-source -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
     ignoreFailure: true

--- a/e2e-tests/tests/features/dbbackup_psmdb/25-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/25-assert.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuttl.dev/v1
+kind: TestAssert
+timeout: 400
+---
+apiVersion: everest.percona.com/v1alpha1
+kind: DatabaseCluster
+metadata:
+  name: test-psmdb-source
+status:
+  ready: 1
+  size: 1
+  status: ready
+---
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDB
+metadata:
+  name: test-psmdb-source
+status:
+  replsets:
+    rs0:
+      initialized: true
+      ready: 1
+      size: 1
+      status: ready
+  state: ready

--- a/e2e-tests/tests/features/dbbackup_psmdb/25-psmdb-cluster-datasource.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/25-psmdb-cluster-datasource.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+---
+apiVersion: everest.percona.com/v1alpha1
+kind: DatabaseCluster
+metadata:
+  name: test-psmdb-source
+spec:
+  dataSource:
+    dbClusterBackupName: test-db-backup
+  engine:
+    type: psmdb
+    replicas: 1
+    storage:
+      size: 1G
+  proxy:
+    type: mongos
+    replicas: 1

--- a/e2e-tests/tests/features/dbbackup_psmdb/90-delete-cluster.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/90-delete-cluster.yaml
@@ -2,7 +2,10 @@ apiVersion: kuttl.dev/v1
 kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
+  - command: kubectl -n $NAMESPACE delete db test-psmdb-source
   - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true
+  - command: kubectl patch psmdb test-psmdb-source -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
     ignoreFailure: true
   - command: kubectl patch backupstorage test-storage-scheduled -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
     ignoreFailure: true

--- a/e2e-tests/tests/features/dbbackup_pxc/25-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/25-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuttl.dev/v1
+kind: TestAssert
+timeout: 500
+---
+apiVersion: everest.percona.com/v1alpha1
+kind: DatabaseCluster
+metadata:
+  name: test-pxc-source
+status:
+  status: ready
+---
+apiVersion: pxc.percona.com/v1
+kind: PerconaXtraDBCluster
+metadata:
+  name: test-pxc-source
+status:
+  state: ready

--- a/e2e-tests/tests/features/dbbackup_pxc/25-pxc-cluster-datasource.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/25-pxc-cluster-datasource.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+---
+apiVersion: everest.percona.com/v1alpha1
+kind: DatabaseCluster
+metadata:
+  name: test-pxc-source
+spec:
+  dataSource:
+    dbClusterBackupName: test-db-backup
+  engine:
+    type: pxc
+    replicas: 1
+    storage:
+      size: 1G
+  proxy:
+    type: haproxy
+    replicas: 1

--- a/e2e-tests/tests/features/dbbackup_pxc/90-delete-cluster.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/90-delete-cluster.yaml
@@ -2,7 +2,10 @@ apiVersion: kuttl.dev/v1
 kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
+  - command: kubectl -n $NAMESPACE delete db test-pxc-source
   - command: kubectl patch backupstorage test-storage-scheduled -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
     ignoreFailure: true
   - command: kubectl patch pxc test-pxc-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true
+  - command: kubectl patch pxc test-pxc-source -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
     ignoreFailure: true


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-682

- In case a DB is to be provisioned from a data source, we copy the credentials from the original DB
- This ensures the DB can be properly provisioned

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [x] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
