### PR TITLE
EVEREST-604 Detect pitr gaps

### DIFF
--- a/api/v1alpha1/databaseclusterbackup_types.go
+++ b/api/v1alpha1/databaseclusterbackup_types.go
@@ -40,6 +40,8 @@ type DatabaseClusterBackupStatus struct {
 	State BackupState `json:"state,omitempty"`
 	// Destination is the full path to the backup.
 	Destination *string `json:"destination,omitempty"`
+	// Gaps identifies if there are gaps detected in the PITR logs
+	Gaps bool `json:"gaps"`
 }
 
 //+kubebuilder:object:root=true

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-12-13T14:59:06Z"
+    createdAt: "2023-12-14T10:51:43Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: everest-operator.v0.6.0-dev1

--- a/bundle/manifests/everest.percona.com_databaseclusterbackups.yaml
+++ b/bundle/manifests/everest.percona.com_databaseclusterbackups.yaml
@@ -85,9 +85,15 @@ spec:
               destination:
                 description: Destination is the full path to the backup.
                 type: string
+              gaps:
+                description: Gaps identifies if there are gaps detected in the PITR
+                  logs
+                type: boolean
               state:
                 description: State is the DatabaseBackup state.
                 type: string
+            required:
+            - gaps
             type: object
         type: object
     served: true

--- a/config/crd/bases/everest.percona.com_databaseclusterbackups.yaml
+++ b/config/crd/bases/everest.percona.com_databaseclusterbackups.yaml
@@ -86,9 +86,15 @@ spec:
               destination:
                 description: Destination is the full path to the backup.
                 type: string
+              gaps:
+                description: Gaps identifies if there are gaps detected in the PITR
+                  logs
+                type: boolean
               state:
                 description: State is the DatabaseBackup state.
                 type: string
+            required:
+            - gaps
             type: object
         type: object
     served: true

--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -66,6 +66,7 @@ const (
 	pgBackupCRDName = "perconapgbackups.pgv2.percona.com"
 
 	dbClusterBackupDBClusterNameField = ".spec.dbClusterName"
+	pxcGapsReasonString               = "BinlogGapDetected"
 )
 
 // ErrBackupStorageUndefined is returned when a backup storage is not defined
@@ -511,6 +512,11 @@ func (r *DatabaseClusterBackupReconciler) reconcilePXC(ctx context.Context, back
 	backup.Status.CompletedAt = pxcCR.Status.CompletedAt
 	backup.Status.CreatedAt = &pxcCR.CreationTimestamp
 	backup.Status.Destination = &pxcCR.Status.Destination
+	for _, condition := range pxcCR.Status.Conditions {
+		if condition.Reason == pxcGapsReasonString {
+			backup.Status.Gaps = true
+		}
+	}
 
 	return r.Status().Update(ctx, backup)
 }

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -170,9 +170,14 @@ spec:
               destination:
                 description: Destination is the full path to the backup.
                 type: string
+              gaps:
+                description: Gaps identifies if there are gaps detected in the PITR logs
+                type: boolean
               state:
                 description: State is the DatabaseBackup state.
                 type: string
+            required:
+            - gaps
             type: object
         type: object
     served: true

--- a/e2e-tests/tests/features/dbbackup_pxc/50-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/50-assert.yaml
@@ -21,6 +21,8 @@ metadata:
 spec:
   storageName: test-storage
   pxcCluster: test-pxc-cluster
+status:
+  gaps: false
 ---
 apiVersion: pxc.percona.com/v1
 kind: PerconaXtraDBCluster

--- a/e2e-tests/tests/features/dbbackup_pxc/50-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/50-assert.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   backupStorageName: test-storage
   dbClusterName: test-pxc-cluster
+status:
+  gaps: false
 ---
 apiVersion: pxc.percona.com/v1
 kind: PerconaXtraDBClusterBackup
@@ -21,8 +23,6 @@ metadata:
 spec:
   storageName: test-storage
   pxcCluster: test-pxc-cluster
-status:
-  gaps: false
 ---
 apiVersion: pxc.percona.com/v1
 kind: PerconaXtraDBCluster


### PR DESCRIPTION
**Detect PITR Gaps**
---
**Problem:**
EVEREST-604

**Cause:**
We want to show a message on the UI if there are gaps detected in pitr logs. There is a way for pxc to detect it, so this PR propagates this information to the `DatabaseClusterBackup` CR

**Solution:**
Add a new field to the `DatabaseClusterBackup` status
