### PR TITLE
EVEREST-739: fix panic for initial PG backup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Scale up cluster
         run: |
-          eksctl scale nodegroup --cluster="$CLUSTER_NAME" --nodes=5 "$NODEPOOL_NAME" --wait
+          eksctl scale nodegroup --cluster="$CLUSTER_NAME" --nodes=10 "$NODEPOOL_NAME" --wait
         env:
           CLUSTER_NAME: "dbaas-ci-20221005"
           NODEPOOL_NAME: "terraform-node-dbaas-ci-20221005"

--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -273,6 +273,12 @@ func (r *DatabaseClusterBackupReconciler) tryCreatePG(ctx context.Context, obj c
 		return err
 	}
 
+	// We want to ignore backups that are done to the hardcoded PVC-based repo1.
+	// This repo only exists to allow users to spin up a PG cluster without specifying a backup storage. Therefore, we don't want to allow users to restore from these backups so shouldn't create a DBB CR from repo1.
+	if pgBackup.Spec.RepoName == "repo1" {
+		return nil
+	}
+
 	backup := &everestv1alpha1.DatabaseClusterBackup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      namespacedName.Name,

--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -274,7 +274,8 @@ func (r *DatabaseClusterBackupReconciler) tryCreatePG(ctx context.Context, obj c
 	}
 
 	// We want to ignore backups that are done to the hardcoded PVC-based repo1.
-	// This repo only exists to allow users to spin up a PG cluster without specifying a backup storage. Therefore, we don't want to allow users to restore from these backups so shouldn't create a DBB CR from repo1.
+	// This repo only exists to allow users to spin up a PG cluster without specifying a backup storage.
+	// Therefore, we don't want to allow users to restore from these backups so shouldn't create a DBB CR from repo1.
 	if pgBackup.Spec.RepoName == "repo1" {
 		return nil
 	}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-739

Operator panics when the first PG backup is created after deploying a DB.

**Cause:**
Invalid index was referred to.

**Solution:**
Prevent `repo1` from being processed.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
