### PR TITLE
EVEREST-405 Push dev image

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -73,6 +73,8 @@ jobs:
             type=match,pattern=v(.*),group=1
             type=match,pattern=v(\d.\d),group=1,enable=${{ !contains(github.ref_name, 'main') }}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, 'rc') }}
+            type=raw,value=0.0.0,enable=${{ contains(github.ref_name, 'main') }}
+
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2


### PR DESCRIPTION
**Dev pipeline fix**
---
**Problem:**
EVEREST-405

Make the operator pipeline push the 0.0.0 image to perconalab on every commit to main
