### PR TITLE
EVEREST-638 PXC restore to a new cluster

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -2745,6 +2745,13 @@ func (r *DatabaseClusterReconciler) reconcileLabels(ctx context.Context, databas
 			needsUpdate = true
 		}
 	}
+	if database.Spec.Backup.PITR.BackupStorageName != nil {
+		if _, ok := database.ObjectMeta.Labels[fmt.Sprintf(backupStorageNameLabelTmpl, *database.Spec.Backup.PITR.BackupStorageName)]; !ok {
+			database.ObjectMeta.Labels[fmt.Sprintf(backupStorageNameLabelTmpl, *database.Spec.Backup.PITR.BackupStorageName)] = backupStorageLabelValue
+			needsUpdate = true
+		}
+	}
+
 	for _, schedule := range database.Spec.Backup.Schedules {
 		if _, ok := database.ObjectMeta.Labels[fmt.Sprintf(backupStorageNameLabelTmpl, schedule.BackupStorageName)]; !ok {
 			database.ObjectMeta.Labels[fmt.Sprintf(backupStorageNameLabelTmpl, schedule.BackupStorageName)] = backupStorageLabelValue


### PR DESCRIPTION
**PXC restore to a new cluster**
---
**Problem:**
EVEREST-638

The restoration to a new cluster already worked, this PR fixes the related issues:
1. Labels reconciliation
2. Improves troubleshooting by trowing errors in case of incorrect configuration  

**Related pull requests**

- [link]

