### PR TITLE
EVEREST-808 EVEREST-810 Fix editing monitoring label

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -2759,7 +2759,8 @@ func (r *DatabaseClusterReconciler) reconcileLabels(ctx context.Context, databas
 		}
 	}
 	if database.Spec.Monitoring != nil && database.Spec.Monitoring.MonitoringConfigName != "" {
-		if _, ok := database.ObjectMeta.Labels[monitoringConfigNameLabel]; !ok {
+		monitoringConfigName, ok := database.ObjectMeta.Labels[monitoringConfigNameLabel]
+		if !ok || monitoringConfigName != database.Spec.Monitoring.MonitoringConfigName {
 			database.ObjectMeta.Labels[monitoringConfigNameLabel] = database.Spec.Monitoring.MonitoringConfigName
 			needsUpdate = true
 		}


### PR DESCRIPTION
**Fix editing monitoring label**
---
**Problem:**
EVEREST-808
EVEREST-810

If users changed the monitoring instance for a given cluster the label wouldn't change.

**Cause:**
We were only updating the monitoring label if it didn't exist.

**Solution:**
Update the monitoring label if it's different to the expected one. 

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~
