### PR TITLE
EVEREST-768 Fix DBC restart race condition

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -192,7 +192,7 @@ func (r *DatabaseClusterReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return reconcile.Result{}, err
 		}
 	}
-	if ok && database.Status.Status == everestv1alpha1.AppStatePaused {
+	if ok && database.Status.Status == everestv1alpha1.AppStatePaused && database.Status.Ready == 0 {
 		logger.Info("Unpausing database cluster")
 		database.Spec.Paused = false
 		delete(database.ObjectMeta.Annotations, restartAnnotationKey)


### PR DESCRIPTION
**Fix DBC restart race condition**
---
**Problem:**
EVEREST-768

During a DBC restart some pods aren't restarted.

**Cause:**
When pausing a PG cluster, the PG operator sets the STS replicas to 0 and sets the state to paused. Since the pods don't immediately go down, if we unpause the cluster the stateful set replicas will go up again and some pods might not be restarted.

**Solution:**
Wait for all pods to go down before reinitializing the DBC.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [x] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
