### PR TITLE
EVEREST-826 Change PG backups type to full

### DIFF
--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -682,6 +682,9 @@ func (r *DatabaseClusterBackupReconciler) reconcilePG(
 		}})
 
 		pgCR.Spec.RepoName = pgDBCR.Spec.Backups.PGBackRest.Repos[repoIdx].Name
+		pgCR.Spec.Options = []string{
+			"--type=full",
+		}
 		return nil
 	})
 	if err != nil {

--- a/e2e-tests/tests/features/dbbackup_pg/20-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/20-assert.yaml
@@ -28,6 +28,8 @@ metadata:
       name: test-db-backup
 spec:
   pgCluster: test-pg-cluster
+  options:
+    - --type=full
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGBackup
@@ -39,6 +41,8 @@ metadata:
       name: test-db-backup-azure
 spec:
   pgCluster: test-pg-cluster
+  options:
+    - --type=full
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGCluster

--- a/e2e-tests/tests/features/dbbackup_pg/50-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/50-assert.yaml
@@ -21,6 +21,8 @@ metadata:
 spec:
   repoName: repo3
   pgCluster: test-pg-cluster
+  options:
+    - --type=full
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGCluster


### PR DESCRIPTION
**Change PG backups type to full**
---
**Problem:**
EVEREST-826

PG on-demand backups were of type incremental instead of full.

**Cause:**
We didn't set any custom option and the default is incremental.

**Solution:**
Set the options to set the type to full.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [x] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
