### PR TITLE
EVERST-822 Restoration fix

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -2461,6 +2461,13 @@ func (r *DatabaseClusterReconciler) reconcilePG(ctx context.Context, req ctrl.Re
 		pg.Finalizers = database.Finalizers
 		database.Finalizers = []string{}
 	}
+
+	// DataSource is not needed anymore when db is ready.
+	// Deleting it to prevent the future restoration conflicts.
+	if database.Status.Status == everestv1alpha1.AppStateReady {
+		database.Spec.DataSource = nil
+	}
+
 	if err := r.Update(ctx, database); err != nil {
 		return err
 	}
@@ -2640,6 +2647,7 @@ func (r *DatabaseClusterReconciler) reconcilePG(ctx context.Context, req ctrl.Re
 			return err
 		}
 
+		pg.Spec.DataSource = nil
 		if database.Spec.DataSource != nil {
 			pg.Spec.DataSource, err = r.genPGDataSourceSpec(ctx, database)
 			if err != nil {


### PR DESCRIPTION
**PG second restoration fix**
---
**Problem:**
EVEREST-822

PG cluster was stuck in initializing after the second restore.

**Cause:**
A restored from DataSource Database couldn't be restored again since the DataSource field was conflicting under the hood with the newest restoration process. 

**Solution:**
Clean up the DataSource field once PG cluster is ready

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
