### PR TITLE
EVEREST-107 | Fix e2e tests getting stuck on deletion of namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
           done
           kubectl delete db --all-namespaces --all
           kubectl delete pvc --all-namespaces --all
+          kubectl delete backupstorage --all-namespaces --all
           kubectl get ns -o name | grep kuttl  | awk -F '/' {'print $2'} | xargs --no-run-if-empty kubectl delete ns
 
       - name: Scale down cluster


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
The e2e tests are failing as deletion of namespaces await proper cleanup of backupstorage resource


**Solution:**
Delete the backupstorage resource first so that the finalizer is handled correctly and namespace is allowed to be cleaned-up

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
