### PR TITLE
Fix MySQL PITR restore to new cluster

### DIFF
--- a/controllers/databaseclusterrestore_controller.go
+++ b/controllers/databaseclusterrestore_controller.go
@@ -390,22 +390,6 @@ func (r *DatabaseClusterRestoreReconciler) restorePXC(
 	return r.Status().Update(ctx, restore)
 }
 
-func (r *DatabaseClusterRestoreReconciler) getSourceDBClusterFromDBBackup(ctx context.Context, bkpName, namespace string) (*everestv1alpha1.DatabaseCluster, error) {
-	// First get the source backup object.
-	backup := &everestv1alpha1.DatabaseClusterBackup{}
-	err := r.Get(ctx, types.NamespacedName{Name: bkpName, Namespace: namespace}, backup)
-	if err != nil {
-		return nil, err
-	}
-	// Get the source cluster the backup belongs to.
-	dbCluster := &everestv1alpha1.DatabaseCluster{}
-	err = r.Get(ctx, types.NamespacedName{Name: backup.Spec.DBClusterName, Namespace: namespace}, dbCluster)
-	if err != nil {
-		return nil, err
-	}
-	return dbCluster, nil
-}
-
 func (r *DatabaseClusterRestoreReconciler) restorePG(ctx context.Context, restore *everestv1alpha1.DatabaseClusterRestore) error {
 	logger := log.FromContext(ctx)
 
@@ -579,7 +563,8 @@ func parsePrefixFromDestination(url string) string {
 func (r *DatabaseClusterRestoreReconciler) genPXCPitrRestoreSpec(
 	ctx context.Context,
 	dataSource everestv1alpha1.DataSource,
-	db everestv1alpha1.DatabaseCluster) (*pxcv1.PITR, error) {
+	db everestv1alpha1.DatabaseCluster,
+) (*pxcv1.PITR, error) {
 	if db.Spec.Backup.PITR.BackupStorageName == nil || *db.Spec.Backup.PITR.BackupStorageName == "" {
 		return nil, fmt.Errorf("no backup storage defined for PITR in %s cluster", db.Name)
 	}

--- a/e2e-tests/tests/features/dbbackup_pxc/51-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/51-assert.yaml
@@ -10,7 +10,10 @@ spec:
   backupName: test-db-backup
   pitr:
     backupSource:
-      storageName: test-storage-scheduled-pitr
+      s3:
+        credentialsSecret: test-pxc-cluster-backup-s3-scheduled
+        endpointUrl: s3.someprovider.com
+        region: us-east-2
     date: "2023-12-06 14:24:42"
     type: date
   pxcCluster: test-pxc-cluster

--- a/e2e-tests/tests/features/dbbackup_pxc/51-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/51-assert.yaml
@@ -11,7 +11,7 @@ spec:
   pitr:
     backupSource:
       s3:
-        credentialsSecret: test-pxc-cluster-backup-s3-scheduled
+        credentialsSecret: test-pxc-cluster-backup-s3
         endpointUrl: s3.someprovider.com
         region: us-east-2
     date: "2023-12-06 14:24:42"


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
[EVEREST-890](https://perconadev.atlassian.net/browse/EVEREST-890)

PITR restore of a MySQL to a new cluster fails.

**Cause:**
When performing a PITR for MySQL, the created pxc-restore object always assumes its own bucket as the backup source. This will not work when we want to PITR restore to a new cluster, as it should use the source cluster's bucket and not its own.

**Solution:**

Updated the PXC restore code so that it uses the same bucket as the one used for the source backup. This way it works for same-cluster and cross-cluster PITR restore.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?


[EVEREST-890]: https://perconadev.atlassian.net/browse/EVEREST-890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ