### PR TITLE
EVEREST-897 Enable track_commit_timestamp

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -2697,19 +2697,23 @@ func (r *DatabaseClusterReconciler) reconcilePG(ctx context.Context, req ctrl.Re
 func (r *DatabaseClusterReconciler) updatePGConfig(
 	pg *pgv2.PerconaPGCluster, db *everestv1alpha1.DatabaseCluster,
 ) error {
-	if db.Spec.Engine.Config == "" {
-		if pg.Spec.Patroni == nil {
-			return nil
-		}
-		pg.Spec.Patroni.DynamicConfiguration = nil
-		return nil
-	}
+	// TODO: uncomment once https://perconadev.atlassian.net/browse/K8SPG-518 done
+	//if db.Spec.Engine.Config == "" {
+	//	if pg.Spec.Patroni == nil {
+	//		return nil
+	//	}
+	//	pg.Spec.Patroni.DynamicConfiguration = nil
+	//	return nil
+	//}
 
 	parser := NewPGConfigParser(db.Spec.Engine.Config)
 	cfg, err := parser.ParsePGConfig()
 	if err != nil {
 		return err
 	}
+
+	// TODO: remove once https://perconadev.atlassian.net/browse/K8SPG-518 done
+	cfg["track_commit_timestamp"] = "on"
 
 	if len(cfg) == 0 {
 		return nil

--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -2697,14 +2697,15 @@ func (r *DatabaseClusterReconciler) reconcilePG(ctx context.Context, req ctrl.Re
 func (r *DatabaseClusterReconciler) updatePGConfig(
 	pg *pgv2.PerconaPGCluster, db *everestv1alpha1.DatabaseCluster,
 ) error {
+	//nolint:godox
 	// TODO: uncomment once https://perconadev.atlassian.net/browse/K8SPG-518 done
-	//if db.Spec.Engine.Config == "" {
-	//	if pg.Spec.Patroni == nil {
-	//		return nil
-	//	}
-	//	pg.Spec.Patroni.DynamicConfiguration = nil
-	//	return nil
-	//}
+	// if db.Spec.Engine.Config == "" {
+	//	 if pg.Spec.Patroni == nil {
+	//		 return nil
+	//	 }
+	//	 pg.Spec.Patroni.DynamicConfiguration = nil
+	//	 return nil
+	// }
 
 	parser := NewPGConfigParser(db.Spec.Engine.Config)
 	cfg, err := parser.ParsePGConfig()
@@ -2712,6 +2713,7 @@ func (r *DatabaseClusterReconciler) updatePGConfig(
 		return err
 	}
 
+	//nolint:godox
 	// TODO: remove once https://perconadev.atlassian.net/browse/K8SPG-518 done
 	cfg["track_commit_timestamp"] = "on"
 

--- a/e2e-tests/tests/core/pg/70-assert.yaml
+++ b/e2e-tests/tests/core/pg/70-assert.yaml
@@ -3,7 +3,7 @@ kind: TestAssert
 timeout: 120
 commands:
   - script: >
-      test "$(kubectl get PerconaPGCluster -n $NAMESPACE test-pg-cluster -o jsonpath='{.spec.patroni.dynamicConfiguration.postgresql.parameters}')" = ""
+      test "$(kubectl get PerconaPGCluster -n $NAMESPACE test-pg-cluster -o jsonpath='{.spec.patroni.dynamicConfiguration.postgresql.parameters}')" = '{"track_commit_timestamp":"on"}'
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGCluster


### PR DESCRIPTION
**Enable track_commit_timestamp for PG**
---
**Problem:**
EVEREST-897

Force enable `track_commit_timestamp` option for PG

**Cause:**
A workaroud for the PITR restoration problem which appears when one tries to restore after the latest transaction.

**Solution:**
Temporary enable `track_commit_timestamp` option so that the user could easily get the date of the latest transaction by calling `select pg_last_committed_xact();`

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
