### PR TITLE
EVEREST-913 fix incorrect LB type for HAProxy replicas svc in EKS

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -975,6 +975,7 @@ func (r *DatabaseClusterReconciler) genPXCHAProxySpec(
 		annotations, ok := exposeAnnotationsMap[clusterType]
 		if ok {
 			haProxy.PodSpec.ServiceAnnotations = annotations
+			haProxy.PodSpec.ReplicasServiceAnnotations = annotations
 		}
 	default:
 		return nil, fmt.Errorf("invalid expose type %s", database.Spec.Proxy.Expose.Type)


### PR DESCRIPTION
**EVEREST-913 fix incorrect LB type for HAProxy replicas svc in EKS**
---
**Problem:**
EVEREST-913

In #132 we fixed an incorrect annotation for the HAProxy primary service's LB for EKS but we forgot to do the same for the HAProxy replicas service LB. This lead us to have a `network` LB for the primary service and a `classic` LB for the replicas.

We should set the same annotation for both services.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~
