### PR TITLE
EVEREST-107 bump go version to 1.22

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go release
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
 
       - name: Install operator-sdk

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ${{ fromJson(inputs.go-version || '["1.21.x"]') }}
+        go-version: ${{ fromJson(inputs.go-version || '["1.22.x"]') }}
         may-fail: [ false ]
 
     env:
@@ -27,7 +27,7 @@ jobs:
         if: env.GO_VERSION != 'tip'
         uses: actions/setup-go@v3
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
 
       - name: Install development tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go release
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
 
       - name: Install tools
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Go release
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
 
       - name: Build operator
@@ -258,7 +258,7 @@ jobs:
       - name: Set up Go release
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
 
       - name: Install operator-sdk

--- a/api/v1alpha1/backupstorage_types.go
+++ b/api/v1alpha1/backupstorage_types.go
@@ -119,7 +119,6 @@ func (b *BackupStorage) IsNamespaceAllowed(namespace string) bool {
 		return true
 	}
 	for _, ns := range b.Spec.AllowedNamespaces {
-		ns := ns
 		if ns == namespace {
 			return true
 		}

--- a/api/v1alpha1/databasecluster_types_test.go
+++ b/api/v1alpha1/databasecluster_types_test.go
@@ -47,7 +47,6 @@ func TestDatabaseClusterReconciler_toCIDR(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -92,7 +91,6 @@ func TestDatabaseCluster_Size(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			if tc.engine.Size() != tc.expectedSize {

--- a/api/v1alpha1/monitoringconfig_types.go
+++ b/api/v1alpha1/monitoringconfig_types.go
@@ -92,7 +92,6 @@ func (m *MonitoringConfig) IsNamespaceAllowed(namespace string) bool {
 		return true
 	}
 	for _, ns := range m.Spec.AllowedNamespaces {
-		ns := ns
 		if ns == namespace {
 			return true
 		}

--- a/controllers/common/helper.go
+++ b/controllers/common/helper.go
@@ -656,12 +656,15 @@ func deleteBackupsForDatabase(
 		return true, nil
 	}
 	for _, backup := range backupList.Items {
-		backup := backup
 		if !backup.GetDeletionTimestamp().IsZero() {
 			// Already deleting, continue to next.
 			continue
 		}
-		if err := c.Delete(ctx, &backup); err != nil {
+		// With the move to go 1.22 it's safe to reuse the same variable, see
+		// https://go.dev/blog/loopvar-preview. However, gosec linter doesn't
+		// like it. Let's disable it for this line until they are updated to
+		// support go 1.22.
+		if err := c.Delete(ctx, &backup); err != nil { //nolint:gosec
 			return false, err
 		}
 	}

--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -720,8 +720,11 @@ func (r *DatabaseClusterReconciler) databaseClustersThatReferenceSecret(ctx cont
 	if err == nil {
 		var items []client.Object
 		for _, i := range bsList.Items {
-			i := i
-			items = append(items, &i)
+			// With the move to go 1.22 it's safe to reuse the same variable,
+			// see https://go.dev/blog/loopvar-preview. However, gosec and
+			// exportloopref linters don't like it. Let's disable them for this
+			// line until they are updated to support go 1.22.
+			items = append(items, &i) //nolint:gosec,exportloopref
 		}
 		res = append(res, r.getDBClustersReconcileRequestsByRelatedObjectName(ctx, items, backupStorageNameField)...)
 	}
@@ -735,8 +738,11 @@ func (r *DatabaseClusterReconciler) databaseClustersThatReferenceSecret(ctx cont
 	if err == nil {
 		var items []client.Object
 		for _, i := range mcList.Items {
-			i := i
-			items = append(items, &i)
+			// With the move to go 1.22 it's safe to reuse the same variable,
+			// see https://go.dev/blog/loopvar-preview. However, gosec and
+			// exportloopref linters don't like it. Let's disable them for this
+			// line until they are updated to support go 1.22.
+			items = append(items, &i) //nolint:gosec,exportloopref
 		}
 		res = append(res, r.getDBClustersReconcileRequestsByRelatedObjectName(ctx, items, monitoringConfigNameField)...)
 	}

--- a/controllers/databaseclusterrestore_controller_test.go
+++ b/controllers/databaseclusterrestore_controller_test.go
@@ -76,7 +76,6 @@ func TestValidatePitrRestoreSpec(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := validatePitrRestoreSpec(tc.data)
@@ -113,7 +112,6 @@ func TestGetPGRestoreOptions(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			res, err := getPGRestoreOptions(tc.data, "smth")

--- a/controllers/databaseengine_controller.go
+++ b/controllers/databaseengine_controller.go
@@ -307,7 +307,6 @@ func (r *DatabaseEngineReconciler) listPendingOperatorUpgrades(
 	upgradeStatus := dbEngine.Status.OperatorUpgrade
 	result := []everestv1alpha1.OperatorUpgrade{}
 	for _, ip := range installPlans.Items {
-		ip := ip
 		for _, csvName := range ip.Spec.ClusterServiceVersionNames {
 			operatorName, version := parseOperatorCSVName(csvName)
 			// Not our operator, skip.
@@ -323,7 +322,11 @@ func (r *DatabaseEngineReconciler) listPendingOperatorUpgrades(
 				continue
 			}
 			// Skip if not owned by current Subscription.
-			if !common.IsOwnedBy(&ip, subscription) {
+			// With the move to go 1.22 it's safe to reuse the same variable,
+			// see https://go.dev/blog/loopvar-preview. However, gosec linter
+			// doesn't like it. Let's disable it for this line until they are
+			// updated to support go 1.22.
+			if !common.IsOwnedBy(&ip, subscription) { //nolint:gosec
 				continue
 			}
 			// Check if the version is greater than the current version.
@@ -361,7 +364,6 @@ func (r *DatabaseEngineReconciler) SetupWithManager(mgr ctrl.Manager, namespaces
 	clientReader := mgr.GetAPIReader()
 	r.versionService = version.NewVersionService()
 	for _, namespaceName := range namespaces {
-		namespaceName := namespaceName
 		for operatorName, engineType := range operatorEngine {
 			dbEngine := &everestv1alpha1.DatabaseEngine{
 				ObjectMeta: metav1.ObjectMeta{

--- a/controllers/providers/pg/pg_test.go
+++ b/controllers/providers/pg/pg_test.go
@@ -107,7 +107,6 @@ func TestPGConfigParser_ParsePGConfig(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -206,7 +205,6 @@ func TestConfigParser_lineUsesEqualSign(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/percona/everest-operator
 
-go 1.21
+go 1.22
 
 require (
 	github.com/AlekSi/pointer v1.2.0

--- a/main.go
+++ b/main.go
@@ -139,7 +139,6 @@ func main() {
 		Version: "v1",
 	})
 	for _, namespaceName := range dbNamespaces {
-		namespaceName := namespaceName
 		err := mgr.GetClient().Get(context.Background(), types.NamespacedName{Name: namespaceName}, namespace)
 		if err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "DatabaseCluster")

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/percona/everest-operator/tools
 
-go 1.21.7
+go 1.22
 
 toolchain go1.22.0
 


### PR DESCRIPTION
Besides bumping go to 1.22, we also removed the unneeded for loop variable copies. See https://go.dev/blog/loopvar-preview for more details on this.