### PR TITLE
EVEREST-107 | Fix e2e test timeouts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,10 +155,7 @@ jobs:
           do
             kubectl -n $namespace get psmdb -o name | awk -F '/' {'print $2'} | xargs --no-run-if-empty kubectl patch psmdb -n $namespace -p '{"metadata":{"finalizers":null}}' --type merge
           done
-          kubectl delete pxc --all-namespaces --all
-          kubectl delete psmdb --all-namespaces --all
-          kubectl delete pg --all-namespaces --all
-          kubectl delete db --all-namespaces --all
+          kubectl delete db --all-namespaces --all --cascade=foreground
           kubectl delete pvc --all-namespaces --all
           kubectl delete backupstorage --all-namespaces --all
           kubectl get ns -o name | grep kuttl  | awk -F '/' {'print $2'} | xargs --no-run-if-empty kubectl delete ns
@@ -204,10 +201,7 @@ jobs:
           do
             kubectl -n $namespace get psmdb -o name | awk -F '/' {'print $2'} | xargs --no-run-if-empty kubectl patch psmdb -n $namespace -p '{"metadata":{"finalizers":null}}' --type merge
           done
-          kubectl delete pxc --all-namespaces --all
-          kubectl delete psmdb --all-namespaces --all
-          kubectl delete pg --all-namespaces --all
-          kubectl delete db --all-namespaces --all
+          kubectl delete db --all-namespaces --all --cascade=foreground
           kubectl delete pvc --all-namespaces --all
           kubectl delete backupstorage --all-namespaces --all
           kubectl get ns -o name | grep kuttl  | awk -F '/' {'print $2'} | xargs --no-run-if-empty kubectl delete ns

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,9 @@ jobs:
           do
             kubectl -n $namespace get psmdb -o name | awk -F '/' {'print $2'} | xargs --no-run-if-empty kubectl patch psmdb -n $namespace -p '{"metadata":{"finalizers":null}}' --type merge
           done
+          kubectl delete pxc --all-namespaces --all
+          kubectl delete psmdb --all-namespaces --all
+          kubectl delete pg --all-namespaces --all
           kubectl delete db --all-namespaces --all
           kubectl delete pvc --all-namespaces --all
           kubectl delete backupstorage --all-namespaces --all
@@ -201,6 +204,9 @@ jobs:
           do
             kubectl -n $namespace get psmdb -o name | awk -F '/' {'print $2'} | xargs --no-run-if-empty kubectl patch psmdb -n $namespace -p '{"metadata":{"finalizers":null}}' --type merge
           done
+          kubectl delete pxc --all-namespaces --all
+          kubectl delete psmdb --all-namespaces --all
+          kubectl delete pg --all-namespaces --all
           kubectl delete db --all-namespaces --all
           kubectl delete pvc --all-namespaces --all
           kubectl delete backupstorage --all-namespaces --all


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-107

Tests are stuck on namespace deletion

**Cause:**

I observed that a namespace was stuck in termination due to a PG resource whose finalizers could not be cleaned-up. This may be due to the fact that the pg operator gets deleted upon ns deletion, even before it has had the change to handle the PG finalizers.

**Solution:**
Ensure that we delete `db` resources in foreground. This ensures that we wait for all child resources to be deleted first, so that any finalizers may be handled, before the operator is deleted.
