### PR TITLE
EVEREST-939 | Ensure Secrets for PITR BackupStorages are copied

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -1161,7 +1161,7 @@ func (r *DatabaseClusterReconciler) genPXCBackupSpec( //nolint:gocognit
 		}
 	}
 
-	if database.Spec.Backup.PITR.Enabled {
+	if database.Spec.Backup.PITR.Enabled { //nolint:nestif
 		storageName := *database.Spec.Backup.PITR.BackupStorageName
 		spec, backupStorage, err := r.genPXCStorageSpec(ctx, storageName, r.systemNamespace)
 		if err != nil {

--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -1188,6 +1188,12 @@ func (r *DatabaseClusterReconciler) genPXCBackupSpec( //nolint:gocognit
 			return nil, fmt.Errorf("BackupStorage of type %s is not supported. PITR only works for s3 compatible storages", backupStorage.Spec.Type)
 		}
 
+		if database.Namespace != r.systemNamespace {
+			if err := r.reconcileBackupStorageSecret(ctx, backupStorage, database); err != nil {
+				return nil, err
+			}
+		}
+
 		// create a separate storage for pxc pitr as the docs recommend
 		// https://docs.percona.com/percona-operator-for-mysql/pxc/backups-pitr.html
 		storages[pitrStorageName(backupStorage.Name)] = spec


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-939

When we have the PITR backupstroage different from the scheduled backups, the Secret from `everest-system` namespace is not copied.


**Solution:**
Ensure that Secrets are copied over similar to how we do for Scheduled backups.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
