### PR TITLE
EVEREST-385 | handle clean-up of dbbackup objects

### DIFF
--- a/controllers/common/consts.go
+++ b/controllers/common/consts.go
@@ -58,6 +58,9 @@ const (
 
 	// EverestSecretsPrefix is the prefix for secrets created by Everest.
 	EverestSecretsPrefix = "everest-secrets-"
+
+	// DBCBackupCleanupFinalizer is the finalizer for cleaning up DatabaseClusterBackup.
+	DBCBackupCleanupFinalizer = "everest.percona.com/dbb-cleanup"
 )
 
 // ExposeAnnotationsMap is a map of annotations needed for exposing the database cluster.

--- a/controllers/providers/pg/provider.go
+++ b/controllers/providers/pg/provider.go
@@ -176,8 +176,15 @@ func (p *Provider) Status(ctx context.Context) (everestv1alpha1.DatabaseClusterS
 }
 
 // Cleanup runs the cleanup routines and returns true if the cleanup is done.
-func (p *Provider) Cleanup(_ context.Context, _ *everestv1alpha1.DatabaseCluster) (bool, error) {
-	// Nothing to do
+func (p *Provider) Cleanup(ctx context.Context, database *everestv1alpha1.DatabaseCluster) (bool, error) {
+	// Handle cleanup of dbb objects.
+	if controllerutil.ContainsFinalizer(database, common.DBCBackupCleanupFinalizer) {
+		if done, err := common.DeleteBackupsForDatabase(ctx, p.C, database.GetName(), database.GetNamespace()); err != nil {
+			return false, err
+		} else if !done {
+			return false, nil
+		}
+	}
 	return true, nil
 }
 

--- a/controllers/providers/psmdb/provider.go
+++ b/controllers/providers/psmdb/provider.go
@@ -168,8 +168,15 @@ func (p *Provider) Status(ctx context.Context) (everestv1alpha1.DatabaseClusterS
 }
 
 // Cleanup runs the cleanup routines and returns true if the cleanup is done.
-func (p *Provider) Cleanup(_ context.Context, _ *everestv1alpha1.DatabaseCluster) (bool, error) {
-	// Nothing to do
+func (p *Provider) Cleanup(ctx context.Context, database *everestv1alpha1.DatabaseCluster) (bool, error) {
+	// Handle cleanup of dbb objects.
+	if controllerutil.ContainsFinalizer(database, common.DBCBackupCleanupFinalizer) {
+		if done, err := common.DeleteBackupsForDatabase(ctx, p.C, database.GetName(), database.GetNamespace()); err != nil {
+			return false, err
+		} else if !done {
+			return false, nil
+		}
+	}
 	return true, nil
 }
 

--- a/controllers/providers/pxc/provider.go
+++ b/controllers/providers/pxc/provider.go
@@ -222,8 +222,15 @@ func (p *Provider) Status(ctx context.Context) (everestv1alpha1.DatabaseClusterS
 }
 
 // Cleanup runs the cleanup routines and returns true if the cleanup is done.
-func (p *Provider) Cleanup(_ context.Context, _ *everestv1alpha1.DatabaseCluster) (bool, error) {
-	// Nothing to do
+func (p *Provider) Cleanup(ctx context.Context, database *everestv1alpha1.DatabaseCluster) (bool, error) {
+	// Handle cleanup of dbb objects.
+	if controllerutil.ContainsFinalizer(database, common.DBCBackupCleanupFinalizer) {
+		if done, err := common.DeleteBackupsForDatabase(ctx, p.C, database.GetName(), database.GetNamespace()); err != nil {
+			return false, err
+		} else if !done {
+			return false, nil
+		}
+	}
 	return true, nil
 }
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**85
EVEREST-3

Deleting databaseclusters does not delete the dbbackup objects.

**Cause:**
We don't set the dbcluster as the owner of the dbbackup (this is by design)

**Solution:**
Set a finalizer on the databasecluster object and run a custom clean-up routine

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
