### PR TITLE
EVEREST-919 Support path-style URL access for Backup Storages

### DIFF
--- a/api/v1alpha1/backupstorage_types.go
+++ b/api/v1alpha1/backupstorage_types.go
@@ -45,6 +45,11 @@ type BackupStorageSpec struct {
 	//
 	// +kubebuilder:default:=true
 	VerifyTLS *bool `json:"verifyTLS,omitempty"`
+	// ForcePathStyle is set to use path-style URLs.
+	// If unspecified, the default value is false.
+	//
+	// +kubebuilder:default:=false
+	ForcePathStyle *bool `json:"forcePathStyle,omitempty"`
 
 	// Description stores description of a backup storage.
 	Description string `json:"description,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -156,6 +156,11 @@ func (in *BackupStorageSpec) DeepCopyInto(out *BackupStorageSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ForcePathStyle != nil {
+		in, out := &in.ForcePathStyle, &out.ForcePathStyle
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AllowedNamespaces != nil {
 		in, out := &in.AllowedNamespaces, &out.AllowedNamespaces
 		*out = make([]string, len(*in))

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-04-10T08:59:01Z"
+    createdAt: "2024-04-10T17:11:58Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: everest-operator.v0.0.0

--- a/bundle/manifests/everest.percona.com_backupstorages.yaml
+++ b/bundle/manifests/everest.percona.com_backupstorages.yaml
@@ -58,6 +58,12 @@ spec:
               endpointURL:
                 description: EndpointURL is an endpoint URL of backup storage.
                 type: string
+              forcePathStyle:
+                default: false
+                description: |-
+                  ForcePathStyle is set to use path-style URLs.
+                  If unspecified, the default value is false.
+                type: boolean
               region:
                 description: Region is a region where the bucket is located.
                 type: string

--- a/config/crd/bases/everest.percona.com_backupstorages.yaml
+++ b/config/crd/bases/everest.percona.com_backupstorages.yaml
@@ -58,6 +58,12 @@ spec:
               endpointURL:
                 description: EndpointURL is an endpoint URL of backup storage.
                 type: string
+              forcePathStyle:
+                default: false
+                description: |-
+                  ForcePathStyle is set to use path-style URLs.
+                  If unspecified, the default value is false.
+                type: boolean
               region:
                 description: Region is a region where the bucket is located.
                 type: string

--- a/controllers/providers/pg/applier.go
+++ b/controllers/providers/pg/applier.go
@@ -46,9 +46,11 @@ const (
 	pgBackupTypeDate      = "time"
 	pgBackupTypeImmediate = "immediate"
 
-	pgBackRestPathTmpl          = "%s-path"
-	pgBackRestRetentionTmpl     = "%s-retention-full"
-	pgBackRestStorageVerifyTmpl = "%s-storage-verify-tls"
+	pgBackRestPathTmpl             = "%s-path"
+	pgBackRestRetentionTmpl        = "%s-retention-full"
+	pgBackRestStorageVerifyTmpl    = "%s-storage-verify-tls"
+	pgBackRestStorageForcePathTmpl = "%s-s3-uri-style"
+	pgBackRestStoragePathStyle     = "path"
 )
 
 type applier struct {
@@ -1081,6 +1083,10 @@ func reconcilePGBackRestRepos(
 				// See: https://pgbackrest.org/configuration.html#section-repository/option-repo-storage-verify-tls
 				pgBackRestGlobal[fmt.Sprintf(pgBackRestStorageVerifyTmpl, repo.Name)] = "n"
 			}
+			if forcePathStyle := pointer.Get(backupStorages[repo.Name].ForcePathStyle); !forcePathStyle {
+				// See: https://pgbackrest.org/configuration.html#section-repository/option-repo-s3-uri-style
+				pgBackRestGlobal[fmt.Sprintf(pgBackRestStorageForcePathTmpl, repo.Name)] = pgBackRestStoragePathStyle
+			}
 
 			err = addBackupStorageCredentialsToPGBackrestSecretIni(
 				sType,
@@ -1142,6 +1148,10 @@ func reconcilePGBackRestRepos(
 				if verify := pointer.Get(backupStorages[repo.Name].VerifyTLS); !verify {
 					// See: https://pgbackrest.org/configuration.html#section-repository/option-repo-storage-verify-tls
 					pgBackRestGlobal[fmt.Sprintf(pgBackRestStorageVerifyTmpl, repo.Name)] = "n"
+				}
+				if forcePathStyle := pointer.Get(backupStorages[repo.Name].ForcePathStyle); !forcePathStyle {
+					// See: https://pgbackrest.org/configuration.html#section-repository/option-repo-s3-uri-style
+					pgBackRestGlobal[fmt.Sprintf(pgBackRestStorageForcePathTmpl, repo.Name)] = pgBackRestStoragePathStyle
 				}
 
 				sType, err := backupStorageTypeFromBackrestRepo(repo)
@@ -1206,6 +1216,10 @@ func reconcilePGBackRestRepos(
 			// See: https://pgbackrest.org/configuration.html#section-repository/option-repo-storage-verify-tls
 			pgBackRestGlobal[fmt.Sprintf(pgBackRestStorageVerifyTmpl, repo.Name)] = "n"
 		}
+		if forcePathStyle := pointer.Get(backupStorages[repo.Name].ForcePathStyle); !forcePathStyle {
+			// See: https://pgbackrest.org/configuration.html#section-repository/option-repo-s3-uri-style
+			pgBackRestGlobal[fmt.Sprintf(pgBackRestStorageForcePathTmpl, repo.Name)] = pgBackRestStoragePathStyle
+		}
 		sType, err := backupStorageTypeFromBackrestRepo(repo)
 		if err != nil {
 			return []crunchyv1beta1.PGBackRestRepo{},
@@ -1258,6 +1272,10 @@ func reconcilePGBackRestRepos(
 		if verify := pointer.Get(backupStorage.VerifyTLS); !verify {
 			// See: https://pgbackrest.org/configuration.html#section-repository/option-repo-storage-verify-tls
 			pgBackRestGlobal[fmt.Sprintf(pgBackRestStorageVerifyTmpl, repo.Name)] = "n"
+		}
+		if forcePathStyle := pointer.Get(backupStorages[repo.Name].ForcePathStyle); !forcePathStyle {
+			// See: https://pgbackrest.org/configuration.html#section-repository/option-repo-s3-uri-style
+			pgBackRestGlobal[fmt.Sprintf(pgBackRestStorageForcePathTmpl, repo.Name)] = pgBackRestStoragePathStyle
 		}
 		sType, err := backupStorageTypeFromBackrestRepo(repo)
 		if err != nil {

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -68,6 +68,12 @@ spec:
               endpointURL:
                 description: EndpointURL is an endpoint URL of backup storage.
                 type: string
+              forcePathStyle:
+                default: false
+                description: |-
+                  ForcePathStyle is set to use path-style URLs.
+                  If unspecified, the default value is false.
+                type: boolean
               region:
                 description: Region is a region where the bucket is located.
                 type: string


### PR DESCRIPTION
**Support path-style URL access for Backup Storages**
---
**Problem:**
EVEREST-919

S3 compatible APIs can support two flavors of bucket hosting styles:

[Path-style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access)

[Virtual-hosted–style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#virtual-hosted-style-access)

Currently everest only supports virtual-hosted style but we should also support the path-style.

**Solution:**
PXC and PSMDB automatically select path-style if needed. PGBackrest needs a config option.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
