### PR TITLE
EVEREST-590 | Fix regression in PXC restores

### DIFF
--- a/controllers/providers/pxc/provider.go
+++ b/controllers/providers/pxc/provider.go
@@ -63,6 +63,8 @@ func New(
 		pxc)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return nil, err
+	} else if k8serrors.IsNotFound(err) {
+		pxc.Spec = defaultSpec()
 	}
 
 	// Add necessary finalizers.
@@ -89,8 +91,6 @@ func New(
 	if err != nil {
 		return nil, err
 	}
-
-	pxc.Spec = defaultSpec()
 
 	p := &Provider{
 		PerconaXtraDBCluster: pxc,


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-590

When performing a restore for PXC, PXCO needs to first pause the database and wait for the pods to scale down. However, the everest-operator removes this pause, leading to the restore process getting stuck.

**Cause:**
Possibly a regression introduced from https://github.com/percona/everest-operator/pull/323

**Solution:**

The code to handle the restore process is already there, however, the PXC spec was getting overwritten. This PR ensures that the spec of the running/existing PXC is preserved

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
