### PR TITLE
EVEREST-999 | handle the case of missing backup during credential secret copying

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -312,6 +312,12 @@ func (r *DatabaseClusterReconciler) copyCredentialsFromDBBackup(
 		Namespace: db.Namespace,
 	}, dbb)
 	if err != nil {
+		// It is possible that the source backup is deleted, for example, if the cluster itself was deleted.
+		// If this happens, we have no way of copying the source credential secrets. So we will return from here,
+		// and let the caller controller take care of failures (if any) resulting from the missing backup/secret.
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return errors.Join(err, errors.New("could not get DB backup to copy credentials from old DB cluster"))
 	}
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-999

Steps to reproduce:
- Create a cluster
- Create a backup
- Restore the backup to a new cluster
- Delete the original cluster
- Delete the restored cluster. This deletion will be stuck.


**Cause:**

The secret credential copying logic assumes that the source backup for restored cluster will be present always. However this assumption does not always hold true, for example in the above scenario.

In https://github.com/percona/everest-operator/pull/356 we added a new improvement where deleting a cluster results in the deletion of all its backups. In this scenario, the source backup was deleted, and the controller was always stuck in the credential copying step since it could not find the backup (and so it never got a chance to finalize the cluster upon deletion)

**Solution:**

During the step where secrets are copied for the backup, it should return without an error if a backup was not found.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
