### PR TITLE
EVEREST-806 | handle upgrade lock annotation

### DIFF
--- a/api/v1alpha1/databaseengine_types.go
+++ b/api/v1alpha1/databaseengine_types.go
@@ -54,6 +54,9 @@ const (
 	// DatabaseOperatorUpgradeAnnotation indicates that the database operator needs to be upgraded.
 	// The value of the annotation is the version to upgrade to.
 	DatabaseOperatorUpgradeAnnotation = "everest.percona.com/upgrade-operator-to"
+	// DatabaseOperatorUpgradeLockAnnotation is an annotation set on the database engine.
+	// If present and set to "true", Everest backend will prevent any resources from being modified in the namespace.
+	DatabaseOperatorUpgradeLockAnnotation = "everest.percona.com/upgrade-lock"
 )
 
 type (

--- a/controllers/databaseengine_controller.go
+++ b/controllers/databaseengine_controller.go
@@ -262,6 +262,7 @@ func (r *DatabaseEngineReconciler) handleOperatorUpgrade(
 		// Upgrade is complete, remove the annotation and mark upgrade as complete.
 		dbEngine.Status.OperatorUpgrade.Phase = everestv1alpha1.UpgradePhaseCompleted
 		delete(annotations, everestv1alpha1.DatabaseOperatorUpgradeAnnotation)
+		delete(annotations, everestv1alpha1.DatabaseOperatorUpgradeLockAnnotation)
 		dbEngine.SetAnnotations(annotations)
 		return false, r.Update(ctx, dbEngine)
 	}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-806

Before starting an operator upgrade, a namespace should be "locked", i.e, no resources should be modified via the Everest API.

**Solution:**

- Everest backend adds a `everest.percona.com/upgrade-lock` annotation on the DBEngine whose operator is being upgraded.
- If this annotation is present, Everest will block any non-GET requests.
- Once upgrade is complete, everest-operator removes this annotation.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
