### PR TITLE
EVEREST-1020 | mysql config should be applied only for engine >=8.0.31

### DIFF
--- a/controllers/providers/pxc/applier.go
+++ b/controllers/providers/pxc/applier.go
@@ -64,10 +64,8 @@ func (p *applier) Engine() error {
 
 	pxc.Spec.SecretsName = p.DB.Spec.Engine.UserSecretsName
 	pxc.Spec.PXC.PodSpec.Size = p.DB.Spec.Engine.Replicas
+	pxc.Spec.PXC.PodSpec.Configuration = p.DB.Spec.Engine.Config
 
-	if p.DB.Spec.Engine.Config != "" {
-		pxc.Spec.PXC.PodSpec.Configuration = p.DB.Spec.Engine.Config
-	}
 	pxcEngineVersion, ok := engine.Status.AvailableVersions.Engine[p.DB.Spec.Engine.Version]
 	if !ok {
 		return fmt.Errorf("engine version %s not available", p.DB.Spec.Engine.Version)

--- a/controllers/providers/pxc/mysqld_configs.go
+++ b/controllers/providers/pxc/mysqld_configs.go
@@ -16,8 +16,14 @@
 package pxc
 
 import (
+	goversion "github.com/hashicorp/go-version"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var (
+	// minVersionForOptimizedConfig is the version below which we will not apply optimized configuration.
+	minVersionForOptimizedConfig, _ = goversion.NewVersion("8.0.31")
 )
 
 const (

--- a/controllers/providers/pxc/mysqld_configs.go
+++ b/controllers/providers/pxc/mysqld_configs.go
@@ -21,10 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-var (
-	// minVersionForOptimizedConfig is the version below which we will not apply optimized configuration.
-	minVersionForOptimizedConfig, _ = goversion.NewVersion("8.0.31")
-)
+// minVersionForOptimizedConfig is the version below which we will not apply optimized configuration.
+var minVersionForOptimizedConfig, _ = goversion.NewVersion("8.0.31")
 
 const (
 	// A pxcConfigSizeSmall is the configuration for PXC cluster with the dimension of 1 vCPU and 2GB RAM.

--- a/controllers/providers/pxc/provider.go
+++ b/controllers/providers/pxc/provider.go
@@ -172,8 +172,8 @@ func (p *Provider) ensureDefaults(ctx context.Context) error {
 		return errors.Join(err, errors.New("cannot parse engine version"))
 	}
 
-	db.Spec.Engine.Config = ""
-	if engineSemVer.GreaterThanOrEqual(minVersionForOptimizedConfig) {
+	if db.Spec.Engine.Config == "" &&
+		engineSemVer.GreaterThanOrEqual(minVersionForOptimizedConfig) {
 		switch db.Spec.Engine.Size() {
 		case everestv1alpha1.EngineSizeSmall:
 			db.Spec.Engine.Config = pxcConfigSizeSmall

--- a/controllers/providers/pxc/provider.go
+++ b/controllers/providers/pxc/provider.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"strings"
 
+	goversion "github.com/hashicorp/go-version"
 	pxcv1 "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	goversion "github.com/hashicorp/go-version"
 	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
 	"github.com/percona/everest-operator/controllers/common"
 	"github.com/percona/everest-operator/controllers/providers"


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1020

The new mysql configs added in https://github.com/percona/everest-operator/pull/309 don't work for engine versions < 8.0.31

**Solution:**
We use the new configs only if the engine version is >= 8.0.31, otherwise we don't specify anything and use the defaults provided by the operator.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
