### PR TITLE
EVEREST-1014 | Fix removal of DataSource for PG restores

### DIFF
--- a/controllers/providers/pg/applier.go
+++ b/controllers/providers/pg/applier.go
@@ -206,6 +206,7 @@ func (p *applier) Backup() error {
 func (p *applier) DataSource() error {
 	if p.DB.Spec.DataSource == nil {
 		// Nothing to do.
+		p.PerconaPGCluster.Spec.DataSource = nil
 		return nil
 	}
 	spec, err := p.genPGDataSourceSpec()

--- a/controllers/providers/pg/applier.go
+++ b/controllers/providers/pg/applier.go
@@ -32,7 +32,6 @@ import (
 	pgv2 "github.com/percona/percona-postgresql-operator/pkg/apis/pgv2.percona.com/v2"
 	crunchyv1beta1 "github.com/percona/percona-postgresql-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -205,26 +204,21 @@ func (p *applier) Backup() error {
 
 func (p *applier) DataSource() error {
 	if p.DB.Spec.DataSource == nil {
-		// Nothing to do.
 		p.PerconaPGCluster.Spec.DataSource = nil
 		return nil
 	}
-	spec, err := p.genPGDataSourceSpec()
-	if err != nil {
-		return err
-	}
-	dbRestore := &everestv1alpha1.DatabaseClusterRestore{}
-	err = p.C.Get(p.ctx, types.NamespacedName{
-		Namespace: p.DB.Namespace,
-		Name:      p.DB.Name,
-	}, dbRestore)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return err
-	}
-	if dbRestore.IsComplete(p.DB.Spec.Engine.Type) {
+
+	// If the Database is ready, we will remove the DataSource.
+	// This will prevent the restore from happening again.
+	if p.DB.Status.Status == everestv1alpha1.AppStateReady {
 		p.DB.Spec.DataSource = nil
 		p.PerconaPGCluster.Spec.DataSource = nil
 		return nil
+	}
+
+	spec, err := p.genPGDataSourceSpec()
+	if err != nil {
+		return err
 	}
 	p.PerconaPGCluster.Spec.DataSource = spec
 	return nil

--- a/controllers/providers/pg/provider.go
+++ b/controllers/providers/pg/provider.go
@@ -91,22 +91,7 @@ func New(
 		return nil, err
 	}
 	p.clusterType = ct
-
-	if err := p.ensureDataSourceRemoved(ctx, opts.DB); err != nil {
-		return nil, err
-	}
 	return p, nil
-}
-
-// DataSource is not needed anymore when db is ready.
-// Deleting it to prevent the future restoration conflicts.
-func (p *Provider) ensureDataSourceRemoved(ctx context.Context, db *everestv1alpha1.DatabaseCluster) error {
-	if db.Status.Status == everestv1alpha1.AppStateReady &&
-		db.Spec.DataSource != nil {
-		db.Spec.DataSource = nil
-		return p.C.Update(ctx, db)
-	}
-	return nil
 }
 
 // Apply returns the PG applier.


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1014

In https://github.com/percona/everest-operator/pull/378, we added a fix to remove the DataSource after the restore was complete. However, the case for PG was not handled correctly.

**Cause:**

The code where the DataSource for PG is removed, assumes that there will be a DatabaseRestore object created, and once it is Complete, the DataSource is set to nil. However, in the case for PG, we don't create DatabaseRestore object for initial restores.

**Solution:**

Do not depend on DatabaseRestores. Instead, check if the cluster is ready and unset the DataSource.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [x] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
