### PR TITLE
EVEREST-1020 | PXC should only compare semver core when applying mysql configs

### DIFF
--- a/controllers/providers/pxc/provider.go
+++ b/controllers/providers/pxc/provider.go
@@ -174,6 +174,7 @@ func (p *Provider) ensureDefaults(ctx context.Context) error {
 	if err != nil {
 		return errors.Join(err, errors.New("cannot parse engine version"))
 	}
+	engineSemVer = engineSemVer.Core()
 
 	if db.Spec.Engine.Config == "" &&
 		engineSemVer.GreaterThanOrEqual(minVersionForOptimizedConfig) {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1020

mysql configs are not being applied for version 8.0.31.

**Cause:**
Semver comparison takes the metadata portion into account as well. Currently we compare against `8.0.31`, however the input version to check for is `8.0.31-23.2`. The semver library takes the `-23.2` into account as well, which results in it being reported as "not equal".

```go
func main() {
	minVer, _ := goversion.NewVersion("8.0.31")
	engineVer, _ := goversion.NewVersion("8.0.31-23.2")
	fmt.Println(engineVer.GreaterThanOrEqual(minVer))        // returns false
	fmt.Println(engineVer.Core().GreaterThanOrEqual(minVer)) // returns true
}

```

**Solution:**
Compare only the core (ignore metadata)

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [x] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
