### PR TITLE
EVEREST-1054 | Fix PG restores for S3 compatible storage locations 

### DIFF
--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -664,7 +664,7 @@ func (r *DatabaseClusterBackupReconciler) getLastPGBackupDestination(
 	httpClient := http.DefaultClient
 	httpClient.Transport = &http.Transport{
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: !pointer.Get(backupStorage.Spec.VerifyTLS),
+			InsecureSkipVerify: !pointer.Get(backupStorage.Spec.VerifyTLS), //nolint:gosec
 		},
 	}
 

--- a/controllers/providers/pg/applier.go
+++ b/controllers/providers/pg/applier.go
@@ -589,7 +589,8 @@ func (p *applier) genPGDataSourceSpec() (*crunchyv1beta1.DataSource, error) {
 func getPGRestoreOptions(
 	dataSource everestv1alpha1.DataSource,
 	backupStorage *everestv1alpha1.BackupStorage,
-	backupBaseName, repoName string) ([]string, error) {
+	backupBaseName, repoName string,
+) ([]string, error) {
 	options := []string{
 		"--set=" + backupBaseName,
 	}

--- a/controllers/providers/pg/applier.go
+++ b/controllers/providers/pg/applier.go
@@ -549,7 +549,7 @@ func (p *applier) genPGDataSourceSpec() (*crunchyv1beta1.DataSource, error) {
 	}
 
 	repoName := "repo1"
-	options, err := getPGRestoreOptions(*database.Spec.DataSource, backupBaseName)
+	options, err := getPGRestoreOptions(*database.Spec.DataSource, backupStorage, backupBaseName, repoName)
 	if err != nil {
 		return nil, err
 	}
@@ -588,9 +588,19 @@ func (p *applier) genPGDataSourceSpec() (*crunchyv1beta1.DataSource, error) {
 	return pgDataSource, nil
 }
 
-func getPGRestoreOptions(dataSource everestv1alpha1.DataSource, backupBaseName string) ([]string, error) {
+func getPGRestoreOptions(
+	dataSource everestv1alpha1.DataSource,
+	backupStorage *everestv1alpha1.BackupStorage,
+	backupBaseName, repoName string) ([]string, error) {
 	options := []string{
 		"--set=" + backupBaseName,
+	}
+
+	if pointer.Get(backupStorage.Spec.ForcePathStyle) {
+		options = append(options, "--"+fmt.Sprintf(pgBackRestStorageForcePathTmpl, repoName)+"="+pgBackRestStoragePathStyle)
+	}
+	if !pointer.Get(backupStorage.Spec.VerifyTLS) {
+		options = append(options, "--no-"+fmt.Sprintf(pgBackRestStorageVerifyTmpl, repoName))
 	}
 
 	if dataSource.PITR != nil {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1054

PG restores do not work when using a backup storage location such as Minio.

**Cause:**
The restore issues are only caused when setting `forcePathStyle` and/or `verifyTLS=false`

#### 1. When restoring to same cluster:
The backup controller lists objects in the S3 storage to build the backup destination path. This S3 API call was failing as the client was not configured for skipping TLS checks or using path-style URIs.

#### 2. When restoring to new cluster:
When performing restores to a new cluster, we did not configure pgBackRest to skip TLS checks or force path-style URIs, depending on the backup storage.


**Solution:**
- Enforce TLS settings and URI style in S3 client while listing S3 objects in the backup controller
- Similarly, configure pgBackRest settings correctly when restoring to a new cluster.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [x] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
