### PR TITLE
EVEREST-1061 | backups should not be reconciled after they've succeeded

### DIFF
--- a/api/v1alpha1/databaseclusterbackup_types.go
+++ b/api/v1alpha1/databaseclusterbackup_types.go
@@ -16,6 +16,9 @@
 package v1alpha1
 
 import (
+	pgv2 "github.com/percona/percona-postgresql-operator/pkg/apis/pgv2.percona.com/v2"
+	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	pxcv1 "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -69,6 +72,13 @@ type DatabaseClusterBackupList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []DatabaseClusterBackup `json:"items"`
+}
+
+// IsComplete returns true if the backup has completed.
+func (b DatabaseClusterBackup) IsComplete() bool {
+	return b.Status.State == BackupState(pxcv1.BackupSucceeded) ||
+		b.Status.State == BackupState(pgv2.BackupSucceeded) ||
+		b.Status.State == BackupState(psmdbv1.BackupStateReady)
 }
 
 func init() {

--- a/api/v1alpha1/databaseclusterbackup_types.go
+++ b/api/v1alpha1/databaseclusterbackup_types.go
@@ -74,11 +74,18 @@ type DatabaseClusterBackupList struct {
 	Items           []DatabaseClusterBackup `json:"items"`
 }
 
-// IsComplete returns true if the backup has completed.
-func (b DatabaseClusterBackup) IsComplete() bool {
+// HasSucceeded returns true if the backup has succeeded.
+func (b DatabaseClusterBackup) HasSucceeded() bool {
 	return b.Status.State == BackupState(pxcv1.BackupSucceeded) ||
 		b.Status.State == BackupState(pgv2.BackupSucceeded) ||
 		b.Status.State == BackupState(psmdbv1.BackupStateReady)
+}
+
+// HasFailed returns true if the backup has failed.
+func (b DatabaseClusterBackup) HasFailed() bool {
+	return b.Status.State == BackupState(pxcv1.BackupFailed) ||
+		b.Status.State == BackupState(pgv2.BackupFailed) ||
+		b.Status.State == BackupState(psmdbv1.BackupStateError)
 }
 
 func init() {

--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -116,7 +116,8 @@ func (r *DatabaseClusterBackupReconciler) Reconcile(ctx context.Context, req ctr
 		return reconcile.Result{}, err
 	}
 
-	if backup.IsComplete() && backup.GetDeletionTimestamp().IsZero() {
+	if (backup.HasSucceeded() || backup.HasFailed()) &&
+		backup.GetDeletionTimestamp().IsZero() {
 		return reconcile.Result{}, err
 	}
 

--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -115,6 +115,11 @@ func (r *DatabaseClusterBackupReconciler) Reconcile(ctx context.Context, req ctr
 		}
 		return reconcile.Result{}, err
 	}
+
+	if backup.IsComplete() && backup.GetDeletionTimestamp().IsZero() {
+		return reconcile.Result{}, err
+	}
+
 	if len(backup.ObjectMeta.Labels) == 0 {
 		backup.ObjectMeta.Labels = map[string]string{
 			databaseClusterNameLabel: backup.Spec.DBClusterName,

--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -118,7 +118,7 @@ func (r *DatabaseClusterBackupReconciler) Reconcile(ctx context.Context, req ctr
 
 	if (backup.HasSucceeded() || backup.HasFailed()) &&
 		backup.GetDeletionTimestamp().IsZero() {
-		return reconcile.Result{}, err
+		return reconcile.Result{}, nil
 	}
 
 	if len(backup.ObjectMeta.Labels) == 0 {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1061

Backups should not be reconciled after they've completed.

**Why is this needed?**

When retentionCopies policy is set, the underlying operators will delete their backup CR. Everest operator sets a bi-directional owner reference between the dbbackup and the upstream backup CR. This could lead to a race condition where the upstream operator deletes the backup CR (due to retention settings) but the Everest operator re-creates it.

This can be fixed if the everest operator does not reconcile backups that have completed.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [x] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
