### PR TITLE
EVEREST-1064 | psmdb-backups should not be adopted by dbbackups until a status is observed

### DIFF
--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -409,6 +409,13 @@ func (r *DatabaseClusterBackupReconciler) tryCreatePSMDB(ctx context.Context, ob
 		return err
 	}
 
+	// Wait until the backup has progressed beyond the waiting state,
+	// otherwise we may observe duplicate backups.
+	// See: https://perconadev.atlassian.net/browse/K8SPSMDB-1088
+	if psmdbBackup.Status.State == "" || psmdbBackup.Status.State == psmdbv1.BackupStateWaiting {
+		return nil
+	}
+
 	backup := &everestv1alpha1.DatabaseClusterBackup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      namespacedName.Name,

--- a/e2e-tests/tests/features/dbbackup_psmdb/70-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/70-assert.yaml
@@ -1,6 +1,9 @@
 apiVersion: kuttl.dev/v1
 kind: TestAssert
 timeout: 100
+commands:
+  - script: >
+      kubectl patch psmdb-backup a-scheduled-backup -n "${NAMESPACE}" --type=merge --subresource status --patch 'status: {state: requested}'
 ---
 apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseClusterBackup


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1064

Duplicate backups are created when specifying a schedule for PSMDB.

**Cause:**
When a backup schedule is specified, PSMDBO automatically creates a psmdb-backup. Upon creation, the backup process starts. However, Everest then modifies the psmdb-backup object by setting an OwnerReference, which triggers another backup run for the same psmdb-backup object, resulting in duplicate backups.

**Solution:**
This is a known issue with PSMDBO, and a fix is expected. As a temporary workaround, Everest should wait for the psmdb-backup to progress beyond "waiting" to be able to adopt the object.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
