### PR TITLE
EVEREST-912 Reconcile complete backups

### DIFF
--- a/e2e-tests/tests/core/dbengine/10-assert.yaml
+++ b/e2e-tests/tests/core/dbengine/10-assert.yaml
@@ -101,6 +101,6 @@ status:
         imagePath: percona/percona-server-mongodb:6.0.5-4
         status: available
       6.0.9-7:
-        imageHash: ef1caec49cc5ea6652731d65ebef468b11da607f2aab11360a47d90aeee5dde5
+        imageHash: 5ef8404e200a680a67f0a94599963e17c029ebe5e0045b60b45062bba127c505
         imagePath: percona/percona-server-mongodb:6.0.9-7
         status: recommended

--- a/e2e-tests/tests/core/dbengine/20-assert.yaml
+++ b/e2e-tests/tests/core/dbengine/20-assert.yaml
@@ -66,6 +66,6 @@ status:
         imagePath: percona/percona-server-mongodb:6.0.5-4
         status: available
       6.0.9-7:
-        imageHash: ef1caec49cc5ea6652731d65ebef468b11da607f2aab11360a47d90aeee5dde5
+        imageHash: 5ef8404e200a680a67f0a94599963e17c029ebe5e0045b60b45062bba127c505
         imagePath: percona/percona-server-mongodb:6.0.9-7
         status: recommended


### PR DESCRIPTION
**Reconcile complete backups**
---
**Problem:**
EVEREST-912

**Why is this needed?**
Successful Everest backup CR needs to be reconciled because the gaps information appears on the pxc-backup resources which needs to be also reflected in the Everest backup. 
However, recently there were [the changes](https://github.com/percona/everest-operator/pull/399) which prevent the complete backups from reconciling because of the retention copies issue. 

This PR still keeps the complete backups from being recreated however the reconciliation still happens over the CR status. 
