### PR TITLE
EVEREST-900 | [bug] Fix nil pointer deref exception

### DIFF
--- a/controllers/backupstorage_controller.go
+++ b/controllers/backupstorage_controller.go
@@ -157,6 +157,9 @@ func (r *BackupStorageReconciler) reconcileUsedNamespaces(ctx context.Context, b
 		}
 		val, found := bs.Status.UsedNamespaces[secret.GetNamespace()]
 		if !found || !val {
+			if bs.Status.UsedNamespaces == nil {
+				bs.Status.UsedNamespaces = make(map[string]bool)
+			}
 			bs.Status.UsedNamespaces[secret.GetNamespace()] = true
 			updated = true
 		}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-900

Introduced a nil pointer dereference exception when merging the functionality of the secret reconciler into the backup storage reconciler.

**Cause:**
Introduced a nil pointer dereference exception when merging the functionality of the secret reconciler into the backup storage reconciler.


**Solution:**
Check for nil pointer first before assignment.