### PR TITLE
EVEREST-1117 | [BUG] fix PG backup status flip-flop

### DIFF
--- a/api/v1alpha1/databaseclusterbackup_types.go
+++ b/api/v1alpha1/databaseclusterbackup_types.go
@@ -94,6 +94,11 @@ func (b DatabaseClusterBackup) HasFailed() bool {
 		b.Status.State == BackupState(psmdbv1.BackupStateError)
 }
 
+// HasCompleted returns true if the backup has completed.
+func (b DatabaseClusterBackup) HasCompleted() bool {
+	return (b.HasSucceeded() || b.HasFailed()) && b.GetDeletionTimestamp().IsZero()
+}
+
 func init() {
 	SchemeBuilder.Register(&DatabaseClusterBackup{}, &DatabaseClusterBackupList{})
 }

--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -506,7 +506,8 @@ func (r *DatabaseClusterBackupReconciler) reconcilePXC(
 	if err := r.Get(ctx,
 		types.NamespacedName{
 			Name:      backup.Name,
-			Namespace: backup.Namespace},
+			Namespace: backup.Namespace,
+		},
 		pxcCR); client.IgnoreNotFound(err) != nil {
 		return false, err
 	}
@@ -581,7 +582,8 @@ func (r *DatabaseClusterBackupReconciler) reconcilePSMDB(
 	}
 	if err := r.Get(ctx, types.NamespacedName{
 		Name:      backup.Name,
-		Namespace: backup.Namespace},
+		Namespace: backup.Namespace,
+	},
 		psmdbCR); client.IgnoreNotFound(err) != nil {
 		return false, err
 	}
@@ -716,7 +718,8 @@ func (r *DatabaseClusterBackupReconciler) reconcilePG(
 	}
 	if err := r.Get(ctx, types.NamespacedName{
 		Name:      backup.GetName(),
-		Namespace: backup.GetNamespace()},
+		Namespace: backup.GetNamespace(),
+	},
 		pgCR); client.IgnoreNotFound(err) != nil {
 		return false, err
 	}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1117

Status of PG DatabaseClusterBackups have their status constantly flip-flop between `Succeeded` and `None`

**Related pull requests**

- https://github.com/percona/everest-operator/pull/406

**Cause:**
We recently made a change where if a backup is complete, the spec is not reconciled, and only the status is reconciled. However, for the case of PG, before reconciling the status, the most recent copy of PerconaPGBackup is not fetched (it was done as a part of the spec reconciliation).

**Solution:**
Get the PerconaPGBackup before updating the status

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
