### PR TITLE
EVEREST-1019 | Unify status for backups and restores

### DIFF
--- a/api/v1alpha1/databaseclusterbackup_types.go
+++ b/api/v1alpha1/databaseclusterbackup_types.go
@@ -33,11 +33,11 @@ const (
 type BackupState string
 
 const (
-	BackupNew       BackupState = ""
-	BackupStarting  BackupState = "Starting"
-	BackupRunning   BackupState = "Running"
-	BackupFailed    BackupState = "Failed"
-	BackupSucceeded BackupState = "Succeeded"
+	BackupNew       BackupState = ""          //nolint:revive
+	BackupStarting  BackupState = "Starting"  //nolint:revive
+	BackupRunning   BackupState = "Running"   //nolint:revive
+	BackupFailed    BackupState = "Failed"    //nolint:revive
+	BackupSucceeded BackupState = "Succeeded" //nolint:revive
 )
 
 // DatabaseClusterBackupSpec defines the desired state of DatabaseClusterBackup.

--- a/api/v1alpha1/databaseclusterbackup_types.go
+++ b/api/v1alpha1/databaseclusterbackup_types.go
@@ -20,6 +20,7 @@ import (
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	pxcv1 "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -30,6 +31,14 @@ const (
 
 // BackupState is used to represent the backup's state.
 type BackupState string
+
+const (
+	BackupNew       BackupState = ""
+	BackupStarting  BackupState = "Starting"
+	BackupRunning   BackupState = "Running"
+	BackupFailed    BackupState = "Failed"
+	BackupSucceeded BackupState = "Succeeded"
+)
 
 // DatabaseClusterBackupSpec defines the desired state of DatabaseClusterBackup.
 type DatabaseClusterBackupSpec struct {
@@ -97,6 +106,65 @@ func (b DatabaseClusterBackup) HasFailed() bool {
 // HasCompleted returns true if the backup has completed.
 func (b DatabaseClusterBackup) HasCompleted() bool {
 	return (b.HasSucceeded() || b.HasFailed()) && b.GetDeletionTimestamp().IsZero()
+}
+
+// GetDBBackupState returns the backup state from the upstream backup object.
+func GetDBBackupState(upstreamBkp client.Object) BackupState {
+	switch bkp := upstreamBkp.(type) {
+	case *pxcv1.PerconaXtraDBClusterBackup:
+		return dbbackupStateFromPXC(bkp)
+	case *pgv2.PerconaPGBackup:
+		return dbbackupStateFromPG(bkp)
+	case *psmdbv1.PerconaServerMongoDBBackup:
+		return dbbackupStateFromPSMDB(bkp)
+	default:
+		return ""
+	}
+}
+
+func dbbackupStateFromPXC(bkp *pxcv1.PerconaXtraDBClusterBackup) BackupState {
+	switch bkp.Status.State {
+	case pxcv1.BackupSucceeded:
+		return BackupSucceeded
+	case pxcv1.BackupFailed:
+		return BackupFailed
+	case pxcv1.BackupRunning:
+		return BackupRunning
+	case pxcv1.BackupStarting:
+		return BackupStarting
+	default:
+		return BackupNew
+	}
+}
+
+func dbbackupStateFromPG(bkp *pgv2.PerconaPGBackup) BackupState {
+	switch bkp.Status.State {
+	case pgv2.BackupSucceeded:
+		return BackupSucceeded
+	case pgv2.BackupFailed:
+		return BackupFailed
+	case pgv2.BackupRunning:
+		return BackupRunning
+	case pgv2.BackupStarting:
+		return BackupStarting
+	default:
+		return BackupNew
+	}
+}
+
+func dbbackupStateFromPSMDB(bkp *psmdbv1.PerconaServerMongoDBBackup) BackupState {
+	switch bkp.Status.State {
+	case psmdbv1.BackupStateReady:
+		return BackupSucceeded
+	case psmdbv1.BackupStateError, psmdbv1.BackupStateRejected:
+		return BackupFailed
+	case psmdbv1.BackupStateRunning:
+		return BackupRunning
+	case psmdbv1.BackupStateWaiting, psmdbv1.BackupStateRequested:
+		return BackupStarting
+	default:
+		return BackupNew
+	}
 }
 
 func init() {

--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -555,7 +555,7 @@ func (r *DatabaseClusterBackupReconciler) reconcilePXC(
 		}
 	}
 
-	backup.Status.State = everestv1alpha1.BackupState(pxcCR.Status.State)
+	backup.Status.State = everestv1alpha1.GetDBBackupState(pxcCR)
 	backup.Status.CompletedAt = pxcCR.Status.CompletedAt
 	backup.Status.CreatedAt = &pxcCR.CreationTimestamp
 	backup.Status.Destination = &pxcCR.Status.Destination
@@ -631,7 +631,7 @@ func (r *DatabaseClusterBackupReconciler) reconcilePSMDB(
 			return false, err
 		}
 	}
-	backup.Status.State = everestv1alpha1.BackupState(psmdbCR.Status.State)
+	backup.Status.State = everestv1alpha1.GetDBBackupState(psmdbCR)
 	backup.Status.CompletedAt = psmdbCR.Status.CompletedAt
 	backup.Status.CreatedAt = &psmdbCR.CreationTimestamp
 	backup.Status.Destination = &psmdbCR.Status.Destination
@@ -776,7 +776,7 @@ func (r *DatabaseClusterBackupReconciler) reconcilePG(
 			return false, err
 		}
 	}
-	backup.Status.State = everestv1alpha1.BackupState(pgCR.Status.State)
+	backup.Status.State = everestv1alpha1.GetDBBackupState(pgCR)
 	backup.Status.CompletedAt = pgCR.Status.CompletedAt
 	backup.Status.CreatedAt = &pgCR.CreationTimestamp
 	// XXX: Until https://jira.percona.com/browse/K8SPG-411 is done

--- a/controllers/databaseclusterrestore_controller.go
+++ b/controllers/databaseclusterrestore_controller.go
@@ -333,7 +333,7 @@ func (r *DatabaseClusterRestoreReconciler) restorePSMDB(
 		return err
 	}
 
-	restore.Status.State = everestv1alpha1.RestoreState(psmdbCR.Status.State)
+	restore.Status.State = everestv1alpha1.GetDBRestoreState(psmdbCR)
 	restore.Status.CompletedAt = psmdbCR.Status.CompletedAt
 	restore.Status.Message = psmdbCR.Status.Error
 
@@ -417,7 +417,7 @@ func (r *DatabaseClusterRestoreReconciler) restorePXC(
 		return err
 	}
 
-	restore.Status.State = everestv1alpha1.RestoreState(pxcCR.Status.State)
+	restore.Status.State = everestv1alpha1.GetDBRestoreState(pxcCR)
 	restore.Status.CompletedAt = pxcCR.Status.CompletedAt
 	restore.Status.Message = pxcCR.Status.Comments
 
@@ -493,7 +493,7 @@ func (r *DatabaseClusterRestoreReconciler) restorePG(ctx context.Context, restor
 		return err
 	}
 
-	restore.Status.State = everestv1alpha1.RestoreState(pgCR.Status.State)
+	restore.Status.State = everestv1alpha1.GetDBRestoreState(pgCR)
 	restore.Status.CompletedAt = pgCR.Status.CompletedAt
 
 	return r.Status().Update(ctx, restore)

--- a/gke_gcloud_auth_plugin_cache
+++ b/gke_gcloud_auth_plugin_cache
@@ -1,0 +1,6 @@
+{
+    "current_context": "cluster",
+    "access_token": "ya29.a0AXooCgsKPDy_3Q-vJjG9fYDjyaLIlUlghElAhUWk8Y6AwPzdwss4Rsf2vmtZZmfCnlnFeafYS2bWjy89AMC-5nQWw3LDzIf8u8yhh1gVdHKAjrKp1XuSJ3cDyxk5_gZfUx2ACvQMkslsiIOEEFKbgm0wA9LxFfIXL_qRMMPgVd-qaCgYKAWwSARISFQHGX2Mio_twqVHCG9q8YVccZpichg0179",
+    "token_expiry": "2024-06-04T08:07:46Z",
+    "extra_args": ""
+}

--- a/gke_gcloud_auth_plugin_cache
+++ b/gke_gcloud_auth_plugin_cache
@@ -1,6 +1,0 @@
-{
-    "current_context": "cluster",
-    "access_token": "ya29.a0AXooCgsKPDy_3Q-vJjG9fYDjyaLIlUlghElAhUWk8Y6AwPzdwss4Rsf2vmtZZmfCnlnFeafYS2bWjy89AMC-5nQWw3LDzIf8u8yhh1gVdHKAjrKp1XuSJ3cDyxk5_gZfUx2ACvQMkslsiIOEEFKbgm0wA9LxFfIXL_qRMMPgVd-qaCgYKAWwSARISFQHGX2Mio_twqVHCG9q8YVccZpichg0179",
-    "token_expiry": "2024-06-04T08:07:46Z",
-    "extra_args": ""
-}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1019

The states for backups/restores differ depending on the underlying database operator type.

**Cause:**
The states are read directly from the underlying CRs.

**Solution:**
Add a list of known states, and add a method to unify them based on the underlying CR.
