### PR TITLE
EVEREST-1145 | Add EKS NLB annotations for PSMDB and PG

### DIFF
--- a/controllers/providers/pg/applier.go
+++ b/controllers/providers/pg/applier.go
@@ -168,6 +168,9 @@ func (p *applier) Proxy() error {
 			Type:                     string(corev1.ServiceTypeLoadBalancer),
 			LoadBalancerSourceRanges: p.DB.Spec.Proxy.Expose.IPSourceRangesStringArray(),
 		}
+		if annotations, ok := common.ExposeAnnotationsMap[p.clusterType]; ok {
+			pg.Spec.Proxy.PGBouncer.ServiceExpose.Metadata.Annotations = annotations
+		}
 	default:
 		return fmt.Errorf("invalid expose type %s", database.Spec.Proxy.Expose.Type)
 	}

--- a/controllers/providers/psmdb/applier.go
+++ b/controllers/providers/psmdb/applier.go
@@ -125,6 +125,9 @@ func (p *applier) Proxy() error {
 		psmdb.Spec.Replsets[0].Expose.Enabled = true
 		psmdb.Spec.Replsets[0].Expose.ExposeType = corev1.ServiceTypeLoadBalancer
 		psmdb.Spec.Replsets[0].Expose.LoadBalancerSourceRanges = database.Spec.Proxy.Expose.IPSourceRangesStringArray()
+		if annotations, ok := common.ExposeAnnotationsMap[p.clusterType]; ok {
+			psmdb.Spec.Replsets[0].Expose.ServiceAnnotations = annotations
+		}
 	default:
 		return fmt.Errorf("invalid expose type %s", database.Spec.Proxy.Expose.Type)
 	}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1145

If users select to enable external access to a DB running in EKS, the provisioned LB should be of the “network” type (NLB) instead of the “classic” type.

**Solution:**
To achieve this, we should set the LB annotation (service.beta.kubernetes.io/aws-load-balancer-type: nlb) in order to provision the AWS network load balancer.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
