### PR TITLE
EVEREST-590 | Fix regression in PXC restores

### DIFF
--- a/api/v1alpha1/databaseclusterrestore_types.go
+++ b/api/v1alpha1/databaseclusterrestore_types.go
@@ -247,12 +247,14 @@ func dbRestoreStateFromPXC(bkp *pxcv1.PerconaXtraDBClusterRestore) RestoreState 
 		return RestoreSucceeded
 	case pxcv1.RestoreFailed:
 		return RestoreFailed
-	case pxcv1.RestoreRestore, pxcv1.RestorePITR, pxcv1.RestoreStartCluster:
+	case pxcv1.RestoreRestore, pxcv1.RestorePITR:
 		return RestoreRunning
-	case pxcv1.RestoreStarting, pxcv1.RestoreStopCluster:
+	case pxcv1.RestoreStarting:
 		return RestoreStarting
-	default:
+	case pxcv1.RestoreNew:
 		return RestoreNew
+	default:
+		return RestoreState(bkp.Status.State)
 	}
 }
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-590

This issue was already fixed in https://github.com/percona/everest-operator/pull/372 , however it has resurfaced (again) after merging https://github.com/percona/everest-operator/pull/410

<img src="https://i.imgflip.com/3a5eiw.jpg?a477384" alt="drawing" width="180"/>

**Cause:**
In https://github.com/percona/everest-operator/pull/410 , we unified the status of the DBRestore CR. For PXC, states such as `Starting Cluster` was merged under `Running`, and `Stopping Cluster` was merged under `Starting`.

However, in our reconciliation, we depend on explicitly checking the states `Starting Cluster` and `Stopping Cluster`, to handle pausing/unpausing the DB when restoring to a new cluster. Since these states disappeared (into Running/Starting), this logic started to fail.

**Solution:**

For DBBackups related to PXC, we preserve the `Starting Cluster` and `Stopping Cluster` states, so that the DB pause/unpause can be handled.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
