### PR TITLE
EVEREST-1167 Restore status fix

### DIFF
--- a/api/v1alpha1/databaseclusterrestore_types.go
+++ b/api/v1alpha1/databaseclusterrestore_types.go
@@ -158,71 +158,11 @@ func init() {
 }
 
 // IsComplete indicates if the restoration process is complete (regardless successful or not).
-func (r *DatabaseClusterRestore) IsComplete(engineType EngineType) bool {
-	switch engineType {
-	case DatabaseEnginePXC:
-		return isPXCRestoreStatusComplete(pxcv1.BcpRestoreStates(r.Status.State))
-	case DatabaseEnginePSMDB:
-		return isPSMDBRestoreStatusComplete(psmdbv1.RestoreState(r.Status.State))
-	case DatabaseEnginePostgresql:
-		return isPGRestoreStatusComplete(pgv2.PGRestoreState(r.Status.State))
-	}
-	return true
-}
-
-func isPXCRestoreStatusComplete(status pxcv1.BcpRestoreStates) bool {
-	switch status {
-	case pxcv1.RestoreNew:
+func (r *DatabaseClusterRestore) IsComplete() bool {
+	switch r.Status.State {
+	case RestoreNew, RestoreStarting, RestoreRunning:
 		return false
-	case pxcv1.RestoreStarting:
-		return false
-	case pxcv1.RestoreStopCluster:
-		return false
-	case pxcv1.RestoreRestore:
-		return false
-	case pxcv1.RestoreStartCluster:
-		return false
-	case pxcv1.RestorePITR:
-		return false
-	case pxcv1.RestoreFailed:
-		return true
-	case pxcv1.RestoreSucceeded:
-		return true
-	}
-	return true
-}
-
-func isPSMDBRestoreStatusComplete(status psmdbv1.RestoreState) bool {
-	switch status {
-	case psmdbv1.RestoreStateNew:
-		return false
-	case psmdbv1.RestoreStateWaiting:
-		return false
-	case psmdbv1.RestoreStateRequested:
-		return false
-	case psmdbv1.RestoreStateRunning:
-		return false
-	case psmdbv1.RestoreStateRejected:
-		return true
-	case psmdbv1.RestoreStateError:
-		return true
-	case psmdbv1.RestoreStateReady:
-		return true
-	}
-	return true
-}
-
-func isPGRestoreStatusComplete(status pgv2.PGRestoreState) bool {
-	switch status {
-	case pgv2.RestoreNew:
-		return false
-	case pgv2.RestoreStarting:
-		return false
-	case pgv2.RestoreRunning:
-		return false
-	case pgv2.RestoreFailed:
-		return true
-	case pgv2.RestoreSucceeded:
+	case RestoreFailed, RestoreSucceeded:
 		return true
 	}
 	return true

--- a/controllers/common/helper.go
+++ b/controllers/common/helper.go
@@ -315,7 +315,7 @@ func ReconcileDBRestoreFromDataSource(
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	}
-	if dbr.IsComplete(database.Spec.Engine.Type) {
+	if dbr.IsComplete() {
 		database.Spec.DataSource = nil
 		return nil
 	}
@@ -585,7 +585,6 @@ func GetDBMonitoringConfig(
 func IsDatabaseClusterRestoreRunning(
 	ctx context.Context,
 	c client.Client,
-	engineType everestv1alpha1.EngineType,
 	dbName, dbNs string,
 ) (bool, error) {
 	// List restores for this database.
@@ -595,7 +594,7 @@ func IsDatabaseClusterRestoreRunning(
 	}
 	// Check if any are not yet complete?
 	for _, restore := range restoreList.Items {
-		if !restore.IsComplete(engineType) {
+		if !restore.IsComplete() {
 			return true, nil
 		}
 	}

--- a/controllers/providers/pg/applier.go
+++ b/controllers/providers/pg/applier.go
@@ -736,7 +736,7 @@ func (p *applier) addBackupStoragesByRestores(
 	c := p.C
 	for _, restore := range restoreList.Items {
 		// If the restore has already completed, skip it.
-		if restore.IsComplete(database.Spec.Engine.Type) {
+		if restore.IsComplete() {
 			continue
 		}
 

--- a/controllers/providers/pg/provider.go
+++ b/controllers/providers/pg/provider.go
@@ -118,7 +118,7 @@ func (p *Provider) Status(ctx context.Context) (everestv1alpha1.DatabaseClusterS
 	status.CRVersion = pg.Spec.CRVersion
 
 	// If a restore is running for this database, set the database status to restoring
-	if restoring, err := common.IsDatabaseClusterRestoreRunning(ctx, c, p.DB.Spec.Engine.Type, p.DB.GetName(), p.DB.GetNamespace()); err != nil {
+	if restoring, err := common.IsDatabaseClusterRestoreRunning(ctx, c, p.DB.GetName(), p.DB.GetNamespace()); err != nil {
 		return status, err
 	} else if restoring {
 		status.Status = everestv1alpha1.AppStateRestoring

--- a/controllers/providers/psmdb/applier.go
+++ b/controllers/providers/psmdb/applier.go
@@ -219,7 +219,7 @@ func (p *applier) addBackupStoragesByRestores(
 	// Add used restore backup storages to the list
 	for _, restore := range restoreList.Items {
 		// If the restore has already completed, skip it.
-		if restore.IsComplete(database.Spec.Engine.Type) {
+		if restore.IsComplete() {
 			continue
 		}
 		// Restores using the BackupSource field instead of the

--- a/controllers/providers/psmdb/provider.go
+++ b/controllers/providers/psmdb/provider.go
@@ -137,7 +137,7 @@ func (p *Provider) Status(ctx context.Context) (everestv1alpha1.DatabaseClusterS
 	status.CRVersion = psmdb.Spec.CRVersion
 
 	// If a restore is running for this database, set the database status to restoring.
-	if restoring, err := common.IsDatabaseClusterRestoreRunning(ctx, p.C, p.DB.Spec.Engine.Type, p.DB.GetName(), p.DB.GetNamespace()); err != nil {
+	if restoring, err := common.IsDatabaseClusterRestoreRunning(ctx, p.C, p.DB.GetName(), p.DB.GetNamespace()); err != nil {
 		return status, err
 	} else if restoring {
 		status.Status = everestv1alpha1.AppStateRestoring

--- a/controllers/providers/pxc/provider.go
+++ b/controllers/providers/pxc/provider.go
@@ -209,7 +209,7 @@ func (p *Provider) Status(ctx context.Context) (everestv1alpha1.DatabaseClusterS
 	status.CRVersion = pxc.Spec.CRVersion
 
 	// If a restore is running for this database, set the database status to restoring.
-	if restoring, err := common.IsDatabaseClusterRestoreRunning(ctx, p.C, p.DB.Spec.Engine.Type, p.DB.GetName(), p.DB.GetNamespace()); err != nil {
+	if restoring, err := common.IsDatabaseClusterRestoreRunning(ctx, p.C, p.DB.GetName(), p.DB.GetNamespace()); err != nil {
 		return status, err
 	} else if restoring {
 		status.Status = everestv1alpha1.AppStateRestoring


### PR DESCRIPTION
**Restore status fix**
---
**Problem:**
EVEREST-1167

There was a regression introduced in https://github.com/percona/everest-operator/pull/410 which cased the restoration falsely considered as Complete for psmdb. 

**Cause:**
The operator was still expecting the old upstream-based statuses for the restore objects, that's why the `isComplete()` function, which was checking if the restore is complete based on the restore's status, wasn't working correctly.
It wasn't prominent for engines other than psmdb bc they use the same strings for statuses as the Everest restore does, but psmdb uses different string values.   

**Solution:**
Use the new statuses to figure out if the restore is complete.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
