### PR TITLE
EVEREST-859 | Ensure backups are deleted in foreground during clean-up

### DIFF
--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -129,7 +129,8 @@ func (r *DatabaseClusterBackupReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	// DBBackups are always deleted in foreground.
-	if controllerutil.AddFinalizer(backup, common.ForegroundDeletionFinalizer) {
+	if backup.GetDeletionTimestamp().IsZero() &&
+		controllerutil.AddFinalizer(backup, common.ForegroundDeletionFinalizer) {
 		if err := r.Update(ctx, backup); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/e2e-tests/tests/features/dbbackup_pg/20-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/20-assert.yaml
@@ -6,6 +6,8 @@ apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseClusterBackup
 metadata:
   name: test-db-backup
+  finalizer:
+  - foregroundDeletion
 spec:
   backupStorageName: test-storage
   dbClusterName: test-pg-cluster
@@ -14,6 +16,8 @@ apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseClusterBackup
 metadata:
   name: test-db-backup-azure
+  finalizer:
+  - foregroundDeletion
 spec:
   backupStorageName: test-storage-azure
   dbClusterName: test-pg-cluster

--- a/e2e-tests/tests/features/dbbackup_pg/20-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/20-assert.yaml
@@ -6,7 +6,7 @@ apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseClusterBackup
 metadata:
   name: test-db-backup
-  finalizer:
+  finalizers:
   - foregroundDeletion
 spec:
   backupStorageName: test-storage
@@ -16,7 +16,7 @@ apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseClusterBackup
 metadata:
   name: test-db-backup-azure
-  finalizer:
+  finalizers:
   - foregroundDeletion
 spec:
   backupStorageName: test-storage-azure

--- a/e2e-tests/tests/features/dbbackup_pg/30-delete-dbb.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/30-delete-dbb.yaml
@@ -1,6 +1,11 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 timeout: 10
+commands:
+  - command: kubectl patch pg-backup test-db-backup -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true
+  - command: kubectl patch pg-backup test-db-backup-azure -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true
 delete:
   - apiVersion: everest.percona.com/v1alpha1
     kind: DatabaseClusterBackup

--- a/e2e-tests/tests/features/dbbackup_pg/50-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/50-assert.yaml
@@ -7,7 +7,7 @@ kind: DatabaseClusterBackup
 metadata:
   name: test-db-backup
   finalizers:
-  - foregrounddeletion
+  - foregroundDeletion
 spec:
   backupStorageName: test-storage
   dbClusterName: test-pg-cluster

--- a/e2e-tests/tests/features/dbbackup_pg/50-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/50-assert.yaml
@@ -6,6 +6,8 @@ apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseClusterBackup
 metadata:
   name: test-db-backup
+  finalizers:
+  - foregrounddeletion
 spec:
   backupStorageName: test-storage
   dbClusterName: test-pg-cluster

--- a/e2e-tests/tests/features/dbbackup_pg/60-delete-dbb.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/60-delete-dbb.yaml
@@ -1,6 +1,9 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 timeout: 10
+commands:
+  - command: kubectl patch pg-backup test-db-backup -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true
 delete:
   - apiVersion: everest.percona.com/v1alpha1
     kind: DatabaseClusterBackup

--- a/e2e-tests/tests/features/dbbackup_pg/70-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pg/70-assert.yaml
@@ -9,6 +9,8 @@ metadata:
   labels:
     backupStorage-test-storage-scheduled: used
     clusterName: test-pg-cluster
+  finalizers:
+  - foregroundDeletion
 spec:
   backupStorageName: test-storage-scheduled
   dbClusterName: test-pg-cluster

--- a/e2e-tests/tests/features/dbbackup_psmdb/20-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/20-assert.yaml
@@ -8,6 +8,7 @@ metadata:
   name: test-db-backup
   finalizers:
   - everest.percona.com/dbb-storage-protection
+  - foregroundDeletion
 spec:
   backupStorageName: test-storage
   dbClusterName: test-psmdb-cluster

--- a/e2e-tests/tests/features/dbbackup_psmdb/30-delete-dbb-s3.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/30-delete-dbb-s3.yaml
@@ -1,6 +1,9 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 timeout: 10
+commands:
+  - command: kubectl patch psmdb-backup test-db-backup -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true
 delete:
   - apiVersion: everest.percona.com/v1alpha1
     kind: DatabaseClusterBackup

--- a/e2e-tests/tests/features/dbbackup_psmdb/31-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/31-assert.yaml
@@ -8,6 +8,7 @@ metadata:
   name: test-db-backup-azure
   finalizers:
   - everest.percona.com/dbb-storage-protection
+  - foregroundDeletion
 spec:
   backupStorageName: test-storage-azure
   dbClusterName: test-psmdb-cluster

--- a/e2e-tests/tests/features/dbbackup_psmdb/32-delete-dbb-azure.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/32-delete-dbb-azure.yaml
@@ -1,6 +1,9 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 timeout: 10
+commands:
+  - command: kubectl patch psmdb-backup test-db-backup-azure -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true
 delete:
   - apiVersion: everest.percona.com/v1alpha1
     kind: DatabaseClusterBackup

--- a/e2e-tests/tests/features/dbbackup_psmdb/70-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/70-assert.yaml
@@ -12,6 +12,8 @@ metadata:
   labels:
     backupStorage-test-storage: used
     clusterName: test-psmdb-cluster
+  finalizers:
+  - foregroundDeletion
 spec:
   backupStorageName: test-storage
   dbClusterName: test-psmdb-cluster

--- a/e2e-tests/tests/features/dbbackup_pxc/20-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/20-assert.yaml
@@ -18,6 +18,7 @@ kind: DatabaseClusterBackup
 metadata:
   name: test-db-backup-azure
   finalizers:
+  - everest.percona.com/dbb-storage-protection
   - foregroundDeletion
 spec:
   backupStorageName: test-storage-azure

--- a/e2e-tests/tests/features/dbbackup_pxc/20-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/20-assert.yaml
@@ -8,6 +8,7 @@ metadata:
   name: test-db-backup
   finalizers:
   - everest.percona.com/dbb-storage-protection
+  - foregroundDeletion
 spec:
   backupStorageName: test-storage
   dbClusterName: test-pxc-cluster
@@ -16,6 +17,8 @@ apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseClusterBackup
 metadata:
   name: test-db-backup-azure
+  finalizers:
+  - foregroundDeletion
 spec:
   backupStorageName: test-storage-azure
   dbClusterName: test-pxc-cluster

--- a/e2e-tests/tests/features/dbbackup_pxc/30-delete-dbb.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/30-delete-dbb.yaml
@@ -1,6 +1,11 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 timeout: 10
+commands:
+  - command: kubectl patch pxc-backup test-db-backup -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true
+  - command: kubectl patch pxc-backup test-db-backup-azure -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true
 delete:
   - apiVersion: everest.percona.com/v1alpha1
     kind: DatabaseClusterBackup

--- a/e2e-tests/tests/features/dbbackup_pxc/50-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/50-assert.yaml
@@ -8,6 +8,7 @@ metadata:
   name: test-db-backup
   finalizers:
   - everest.percona.com/dbb-storage-protection
+  - foregroundDeletion
 spec:
   backupStorageName: test-storage
   dbClusterName: test-pxc-cluster

--- a/e2e-tests/tests/features/dbbackup_pxc/60-delete-dbb.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/60-delete-dbb.yaml
@@ -1,6 +1,9 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 timeout: 10
+commands:
+  - command: kubectl patch pxc-backup test-db-backup -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+    ignoreFailure: true
 delete:
   - apiVersion: everest.percona.com/v1alpha1
     kind: DatabaseClusterBackup

--- a/e2e-tests/tests/features/dbbackup_pxc/70-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_pxc/70-assert.yaml
@@ -9,6 +9,8 @@ metadata:
   labels:
     backupStorage-test-storage-scheduled: used
     clusterName: test-pxc-cluster
+  finalizers:
+  - foregroundDeletion
 spec:
   backupStorageName: test-storage-scheduled
   dbClusterName: test-pxc-cluster


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-859

When uninstalling Everest via the CLI, the DB gets deleted before the backups can be cleaned-up properly

**Cause:**
We're not setting the `foregroundDeletion` finaliser.

**Solution:**
Set the finalizer at the time of performing the cleanup. Currently, the finalizers are added from different places (like from the API server). With this approach, we can unify the clean-up process, so that we don't have to explicitly add finalizers from the API server.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
