### PR TITLE
EVEREST-913 fix HAProxy replicas LB type

### DIFF
--- a/controllers/providers/pxc/applier.go
+++ b/controllers/providers/pxc/applier.go
@@ -285,6 +285,7 @@ func (p *applier) applyHAProxyCfg() error {
 			Annotations:              annotations,
 		}
 		haProxy.ExposePrimary = expose
+		haProxy.ExposeReplicas = &expose
 	default:
 		return fmt.Errorf("invalid expose type %s", p.DB.Spec.Proxy.Expose.Type)
 	}


### PR DESCRIPTION
**Problem:**
EVEREST-913


**Related pull requests**

- #324 
- #415 

**Cause:**
When we introduced PXCO 1.14 we forgot to expose the HAProxy Replicas leading to a regression on EVEREST-913

**Solution:**
Expose the HAProxy replicas

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
