### PR TITLE
[bug] watchers should be configured only if recognised by the scheme

### DIFF
--- a/controllers/common/consts.go
+++ b/controllers/common/consts.go
@@ -15,6 +15,8 @@
 
 package common
 
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
 const (
 	// DefaultPMMClientImage is the default image for PMM client.
 	DefaultPMMClientImage = "percona/pmm-client:2"
@@ -72,3 +74,13 @@ var ExposeAnnotationsMap = map[ClusterType]map[string]string{
 		"service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
 	},
 }
+
+//noling:gochecknoglobals
+var (
+	// PXCGVK is the GroupVersionKind for Percona XtraDB Cluster.
+	PXCGVK = schema.GroupVersionKind{Group: PXCAPIGroup, Version: "v1", Kind: PerconaXtraDBClusterKind}
+	// PSMDBGVK is the GroupVersionKind for Percona Server for MongoDB.
+	PSMDBGVK = schema.GroupVersionKind{Group: PSMDBAPIGroup, Version: "v1", Kind: PerconaServerMongoDBKind}
+	// PGGVK is the GroupVersionKind for Percona PostgreSQL.
+	PGGVK = schema.GroupVersionKind{Group: PGAPIGroup, Version: "v2", Kind: PerconaPGClusterKind}
+)

--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -657,21 +657,27 @@ func (r *DatabaseClusterReconciler) initWatchers(controller *builder.Builder) {
 		builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 	)
 
-	controller.Watches(
-		&psmdbv1.PerconaServerMongoDB{},
-		&handler.EnqueueRequestForObject{},
-		builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
-	)
-	controller.Watches(
-		&pgv2.PerconaPGCluster{},
-		&handler.EnqueueRequestForObject{},
-		builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
-	)
-	controller.Watches(
-		&pxcv1.PerconaXtraDBCluster{},
-		&handler.EnqueueRequestForObject{},
-		builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
-	)
+	if r.Scheme.Recognizes(common.PSMDBGVK) {
+		controller.Watches(
+			&psmdbv1.PerconaServerMongoDB{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		)
+	}
+	if r.Scheme.Recognizes(common.PGGVK) {
+		controller.Watches(
+			&pgv2.PerconaPGCluster{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		)
+	}
+	if r.Scheme.Recognizes(common.PXCGVK) {
+		controller.Watches(
+			&pxcv1.PerconaXtraDBCluster{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		)
+	}
 }
 
 func (r *DatabaseClusterReconciler) databaseClustersInObjectNamespace(ctx context.Context, obj client.Object) []reconcile.Request {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-0

Everest operator crashes when not all DB operators are installed.

**Related pull requests**

- [link]

**Cause:**
The DB controller, during initialisation, adds the DB CRDs to the scheme only if they are installed. However, we are setting up watchers for the CRs without checking if they are recognised by the scheme, which leads to a crash.

**Solution:**
Before setting up the watch, check if the Scheme recognises the CRD. The CRDs are added to the scheme only if they are installed first.
