### PR TITLE
Revert "EVEREST-969: no parallel backups"

### DIFF
--- a/controllers/providers/pxc/applier.go
+++ b/controllers/providers/pxc/applier.go
@@ -466,8 +466,7 @@ func (p *applier) genPXCBackupSpec() (*pxcv1.PXCScheduledBackup, error) {
 
 	// Initialize PXCScheduledBackup object
 	pxcBackupSpec := &pxcv1.PXCScheduledBackup{
-		AllowParallel: pointer.ToBool(false),
-		Image:         backupVersion.ImagePath,
+		Image: backupVersion.ImagePath,
 		PITR: pxcv1.PITRSpec{
 			Enabled: database.Spec.Backup.PITR.Enabled,
 		},


### PR DESCRIPTION
Reverts percona/everest-operator#429
Due to a [bug in the PXCOperator](https://perconadev.atlassian.net/browse/K8SPXC-1416) we need to revert this PR until it's fixed.

[EVEREST-969]: https://perconadev.atlassian.net/browse/EVEREST-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ