### PR TITLE
EVEREST-1244 PXC restoration status fix

### DIFF
--- a/api/v1alpha1/databaseclusterrestore_types.go
+++ b/api/v1alpha1/databaseclusterrestore_types.go
@@ -187,14 +187,12 @@ func dbRestoreStateFromPXC(bkp *pxcv1.PerconaXtraDBClusterRestore) RestoreState 
 		return RestoreSucceeded
 	case pxcv1.RestoreFailed:
 		return RestoreFailed
-	case pxcv1.RestoreRestore, pxcv1.RestorePITR:
+	case pxcv1.RestoreRestore, pxcv1.RestorePITR, pxcv1.RestoreStartCluster:
 		return RestoreRunning
-	case pxcv1.RestoreStarting:
+	case pxcv1.RestoreStarting, pxcv1.RestoreStopCluster:
 		return RestoreStarting
-	case pxcv1.RestoreNew:
-		return RestoreNew
 	default:
-		return RestoreState(bkp.Status.State)
+		return RestoreNew
 	}
 }
 

--- a/controllers/common/consts.go
+++ b/controllers/common/consts.go
@@ -49,6 +49,8 @@ const (
 	PerconaServerMongoDBKind = "PerconaServerMongoDB"
 	// PerconaPGClusterKind is the kind for Percona PostgreSQL.
 	PerconaPGClusterKind = "PerconaPGCluster"
+	// PerconaXtraDBClusterRestoreKind is the kind for Percona XtraDB Cluster restore.
+	PerconaXtraDBClusterRestoreKind = "PerconaXtraDBClusterRestore"
 
 	// ClusterTypeEKS represents the EKS cluster type.
 	ClusterTypeEKS ClusterType = "eks"
@@ -79,6 +81,8 @@ var ExposeAnnotationsMap = map[ClusterType]map[string]string{
 var (
 	// PXCGVK is the GroupVersionKind for Percona XtraDB Cluster.
 	PXCGVK = schema.GroupVersionKind{Group: PXCAPIGroup, Version: "v1", Kind: PerconaXtraDBClusterKind}
+	// PXCRGVK is the GroupVersionKind for Percona PostgreSQL.
+	PXCRGVK = schema.GroupVersionKind{Group: PXCAPIGroup, Version: "v1", Kind: PerconaXtraDBClusterRestoreKind}
 	// PSMDBGVK is the GroupVersionKind for Percona Server for MongoDB.
 	PSMDBGVK = schema.GroupVersionKind{Group: PSMDBAPIGroup, Version: "v1", Kind: PerconaServerMongoDBKind}
 	// PGGVK is the GroupVersionKind for Percona PostgreSQL.

--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -657,6 +657,29 @@ func (r *DatabaseClusterReconciler) initWatchers(controller *builder.Builder) {
 		builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 	)
 
+	controller.Watches(
+		// need to watch pxc-restore since to be sure the db is reconciled on every pxc-restore status update.
+		// watching the dbr is not enough since the operator merges the statuses but we need to pause the db exactly when
+		// the pxc-restore got to the pxcv1.RestoreStopCluster status
+		&pxcv1.PerconaXtraDBClusterRestore{},
+		handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
+			pxcRestore, ok := obj.(*pxcv1.PerconaXtraDBClusterRestore)
+			if !ok {
+				return []reconcile.Request{}
+			}
+			return []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						// db name to reconcile is the same as the pxc cluster name
+						Name:      pxcRestore.Spec.PXCCluster,
+						Namespace: obj.GetNamespace(),
+					},
+				},
+			}
+		}),
+		builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+	)
+
 	if r.Scheme.Recognizes(common.PSMDBGVK) {
 		controller.Watches(
 			&psmdbv1.PerconaServerMongoDB{},

--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -418,7 +418,8 @@ func (r *DatabaseClusterReconciler) reconcileLabels(
 func (r *DatabaseClusterReconciler) addPXCKnownTypes(scheme *runtime.Scheme) error {
 	pxcSchemeGroupVersion := schema.GroupVersion{Group: common.PXCAPIGroup, Version: "v1"}
 	scheme.AddKnownTypes(pxcSchemeGroupVersion,
-		&pxcv1.PerconaXtraDBCluster{}, &pxcv1.PerconaXtraDBClusterList{})
+		&pxcv1.PerconaXtraDBCluster{}, &pxcv1.PerconaXtraDBClusterList{},
+		&pxcv1.PerconaXtraDBClusterRestore{}, &pxcv1.PerconaXtraDBClusterRestoreList{})
 
 	metav1.AddToGroupVersion(scheme, pxcSchemeGroupVersion)
 	return nil
@@ -657,28 +658,30 @@ func (r *DatabaseClusterReconciler) initWatchers(controller *builder.Builder) {
 		builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 	)
 
-	controller.Watches(
-		// need to watch pxc-restore since to be sure the db is reconciled on every pxc-restore status update.
-		// watching the dbr is not enough since the operator merges the statuses but we need to pause the db exactly when
-		// the pxc-restore got to the pxcv1.RestoreStopCluster status
-		&pxcv1.PerconaXtraDBClusterRestore{},
-		handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
-			pxcRestore, ok := obj.(*pxcv1.PerconaXtraDBClusterRestore)
-			if !ok {
-				return []reconcile.Request{}
-			}
-			return []reconcile.Request{
-				{
-					NamespacedName: types.NamespacedName{
-						// db name to reconcile is the same as the pxc cluster name
-						Name:      pxcRestore.Spec.PXCCluster,
-						Namespace: obj.GetNamespace(),
+	if r.Scheme.Recognizes(common.PXCRGVK) {
+		controller.Watches(
+			// need to watch pxc-restore to be sure the db is reconciled on every pxc-restore status update.
+			// watching the dbr is not enough since the operator merges the statuses but we need to pause the db exactly when
+			// the pxc-restore got to the pxcv1.RestoreStopCluster status
+			&pxcv1.PerconaXtraDBClusterRestore{},
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
+				pxcRestore, ok := obj.(*pxcv1.PerconaXtraDBClusterRestore)
+				if !ok {
+					return []reconcile.Request{}
+				}
+				return []reconcile.Request{
+					{
+						NamespacedName: types.NamespacedName{
+							// db name to reconcile is the same as the pxc cluster name
+							Name:      pxcRestore.Spec.PXCCluster,
+							Namespace: obj.GetNamespace(),
+						},
 					},
-				},
-			}
-		}),
-		builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
-	)
+				}
+			}),
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		)
+	}
 
 	if r.Scheme.Recognizes(common.PSMDBGVK) {
 		controller.Watches(

--- a/controllers/providers/pxc/provider.go
+++ b/controllers/providers/pxc/provider.go
@@ -19,6 +19,7 @@ package pxc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	goversion "github.com/hashicorp/go-version"
@@ -110,7 +111,7 @@ func New(
 	if err := p.ensureDefaults(ctx); err != nil {
 		return nil, err
 	}
-	if err := p.handlePauseForPXCRestore(ctx); err != nil {
+	if err := p.handlePauseForPXCRestore(ctx, opts); err != nil {
 		return nil, err
 	}
 	return p, nil
@@ -130,23 +131,28 @@ func (p *Provider) Apply(ctx context.Context) everestv1alpha1.Applier {
 // The pause may be overwritten since the Everest operator will also fight for the desired pause state
 // set by the user.
 // To avoid this race condition, we will explicitly inspect every phase of the restore, and set pause accordingly.
-func (p *Provider) handlePauseForPXCRestore(ctx context.Context) error {
-	restores, err := common.ListDatabaseClusterRestores(ctx, p.C, p.DB.GetName(), p.DB.GetNamespace())
-	if err != nil {
-		return err
+func (p *Provider) handlePauseForPXCRestore(ctx context.Context, opts providers.ProviderOptions) error {
+	c := opts.C
+	restores := &pxcv1.PerconaXtraDBClusterRestoreList{}
+	if err := c.List(ctx, restores); err != nil {
+		return fmt.Errorf("failed to list pxcRestore objects: %w", err)
 	}
 	if len(restores.Items) == 0 {
 		return nil
 	}
 	for _, restore := range restores.Items {
-		if restore.Status.State == everestv1alpha1.RestoreState(pxcv1.RestoreSucceeded) {
+		// since there is no index for the .spec.pxcCluster field in pxc-restore, the filter is handled manually
+		if restore.Spec.PXCCluster != opts.DB.Name {
 			continue
 		}
-		if restore.Status.State == everestv1alpha1.RestoreState(pxcv1.RestoreStopCluster) {
+		if restore.Status.State == pxcv1.RestoreSucceeded {
+			continue
+		}
+		if restore.Status.State == pxcv1.RestoreStopCluster {
 			p.DB.Spec.Paused = true
 			return p.C.Update(ctx, p.DB)
 		}
-		if restore.Status.State == everestv1alpha1.RestoreState(pxcv1.RestoreStartCluster) {
+		if restore.Status.State == pxcv1.RestoreStartCluster {
 			p.DB.Spec.Paused = false
 			return p.C.Update(ctx, p.DB)
 		}

--- a/controllers/providers/pxc/provider.go
+++ b/controllers/providers/pxc/provider.go
@@ -132,9 +132,8 @@ func (p *Provider) Apply(ctx context.Context) everestv1alpha1.Applier {
 // set by the user.
 // To avoid this race condition, we will explicitly inspect every phase of the restore, and set pause accordingly.
 func (p *Provider) handlePauseForPXCRestore(ctx context.Context, opts providers.ProviderOptions) error {
-	c := opts.C
 	restores := &pxcv1.PerconaXtraDBClusterRestoreList{}
-	if err := c.List(ctx, restores); err != nil {
+	if err := opts.C.List(ctx, restores); err != nil {
 		return fmt.Errorf("failed to list pxcRestore objects: %w", err)
 	}
 	if len(restores.Items) == 0 {


### PR DESCRIPTION
**PXC restoration status update**
---
**Problem:**
EVEREST-1244

**Problem:**
When a PXC cluster is in the "Stopping Cluster" or "Starting Cluster" state during the restoration it's not considered as a restoring status and as a result the FE doesn't block actions over the cluster. 

This behaviour was intentionally introduced in https://github.com/percona/everest-operator/pull/435, because
>  in our reconciliation, we depend on explicitly checking the states Starting Cluster and Stopping Cluster, to handle pausing/unpausing the DB when restoring to a new cluster. Since these states disappeared (into Running/Starting), this logic started to fail. 

**Solution:**
1. revert the https://github.com/percona/everest-operator/pull/435, so Everest would again merge the states such as `Starting Cluster` under `Running`, and `Stopping Cluster` under `Starting`.
2. handle the pxc cluster pausing logic based on the `pxc-restore` CR status but not on the `dbr` status 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
