### PR TITLE
EVEREST-1278 Fix new PG DBs getting stuck in Unknown state after deleting a PG DB

### DIFF
--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-07-16T07:47:08Z"
+    createdAt: "2024-07-26T15:02:18Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: everest-operator.v0.0.0
@@ -168,6 +168,7 @@ spec:
           verbs:
           - get
           - list
+          - update
           - watch
         - apiGroups:
           - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,7 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/controllers/common/helper.go
+++ b/controllers/common/helper.go
@@ -697,6 +697,17 @@ func GetRecommendedCRVersion(
 	return nil, nil //nolint:nilnil
 }
 
+// DeploymentIsReady returns true if the deployment is ready.
+func DeploymentIsReady(ctx context.Context, c client.Client, name types.NamespacedName) (bool, error) {
+	deployment := &appsv1.Deployment{}
+	err := c.Get(ctx, name, deployment)
+	if err != nil {
+		return false, err
+	}
+
+	return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas, nil
+}
+
 // RestartDeployment restarts the deployment.
 func RestartDeployment(
 	ctx context.Context,

--- a/controllers/common/helper.go
+++ b/controllers/common/helper.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/AlekSi/pointer"
 	crunchyv1beta1 "github.com/percona/percona-postgresql-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
@@ -694,4 +695,22 @@ func GetRecommendedCRVersion(
 		return pointer.To(v.ToCRVersion()), nil
 	}
 	return nil, nil //nolint:nilnil
+}
+
+// RestartDeployment restarts the deployment.
+func RestartDeployment(
+	ctx context.Context,
+	c client.Client,
+	name types.NamespacedName,
+) error {
+	deployment := &appsv1.Deployment{}
+	err := c.Get(ctx, name, deployment)
+	if err != nil {
+		return err
+	}
+	if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+		deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	deployment.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = metav1.Now().Format(time.RFC3339)
+	return c.Update(ctx, deployment)
 }

--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -199,7 +199,7 @@ func (r *DatabaseClusterReconciler) reconcileDB(
 //+kubebuilder:rbac:groups=everest.percona.com,resources=databaseclusters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=everest.percona.com,resources=databaseclusters/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=everest.percona.com,resources=databaseclusters/finalizers,verbs=update
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;update;watch
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=pxc.percona.com,resources=perconaxtradbclusters,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -135,8 +135,11 @@ func (r *DatabaseClusterReconciler) reconcileDB(
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		db.Status.Status = everestv1alpha1.AppStateDeleting
-		return ctrl.Result{Requeue: !done}, r.Status().Update(ctx, db)
+		if !done {
+			db.Status.Status = everestv1alpha1.AppStateDeleting
+			return ctrl.Result{Requeue: true}, r.Client.Status().Update(ctx, db)
+		}
+		return ctrl.Result{}, nil
 	}
 
 	// Set metadata.

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -1142,6 +1142,7 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/e2e-tests/tests/features/multinamespace_psmdb/10-psmdb-cluster-with-schedule.yaml
+++ b/e2e-tests/tests/features/multinamespace_psmdb/10-psmdb-cluster-with-schedule.yaml
@@ -55,7 +55,7 @@ spec:
     type: psmdb
     replicas: 1
     storage:
-      size: 1G
+      size: 1Gi
   proxy:
     type: haproxy
     replicas: 1

--- a/e2e-tests/tests/features/multinamespace_psmdb/20-psmdb-cluster-with-schedule.yaml
+++ b/e2e-tests/tests/features/multinamespace_psmdb/20-psmdb-cluster-with-schedule.yaml
@@ -17,7 +17,7 @@ spec:
     type: psmdb
     replicas: 1
     storage:
-      size: 1G
+      size: 1Gi
   proxy:
     type: haproxy
     replicas: 1

--- a/e2e-tests/tests/features/scheduled_backups/02-assert.yaml
+++ b/e2e-tests/tests/features/scheduled_backups/02-assert.yaml
@@ -19,7 +19,7 @@ spec:
       cpu: 500m
       memory: 1G
     storage:
-      size: 15G
+      size: 15Gi
   proxy:
     type: mongos
     replicas: 1

--- a/e2e-tests/tests/features/scheduled_backups/02-psmdb.yaml
+++ b/e2e-tests/tests/features/scheduled_backups/02-psmdb.yaml
@@ -30,7 +30,7 @@ spec:
       cpu: 500m
       memory: 1G
     storage:
-      size: 15G
+      size: 15Gi
   proxy:
     type: mongos
     replicas: 1

--- a/e2e-tests/tests/upgrade/pg/30-assert.yaml
+++ b/e2e-tests/tests/upgrade/pg/30-assert.yaml
@@ -24,3 +24,15 @@ spec:
       replicas: 1
       expose:
         type: ClusterIP
+status:
+  pgbouncer:
+    ready: 1
+    size: 1
+  postgres:
+    instances:
+    - name: instance1
+      ready: 1
+      size: 1
+    ready: 1
+    size: 1
+  state: ready

--- a/e2e-tests/tests/upgrade/psmdb/10-assert.yaml
+++ b/e2e-tests/tests/upgrade/psmdb/10-assert.yaml
@@ -19,6 +19,10 @@ spec:
     type: mongos
   backup:
     enabled: false
+status:
+  ready: 1
+  size: 1
+  status: ready
 ---
 apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB
@@ -28,3 +32,13 @@ spec:
   crVersion: 1.15.0
   multiCluster:
     enabled: false
+status:
+  replsets:
+    rs0:
+      initialized: true
+      ready: 1
+      size: 1
+      status: ready
+  ready: 1
+  size: 1
+  state: ready

--- a/e2e-tests/tests/upgrade/psmdb/10-assert.yaml
+++ b/e2e-tests/tests/upgrade/psmdb/10-assert.yaml
@@ -10,7 +10,7 @@ spec:
   engine:
     replicas: 1
     storage:
-      size: 1G
+      size: 1Gi
     type: psmdb
   proxy:
     expose:

--- a/e2e-tests/tests/upgrade/psmdb/10-psmdb-cluster-no-schedule.yaml
+++ b/e2e-tests/tests/upgrade/psmdb/10-psmdb-cluster-no-schedule.yaml
@@ -11,7 +11,7 @@ spec:
     type: psmdb
     replicas: 1
     storage:
-      size: 1G
+      size: 1Gi
   proxy:
     type: mongos
     replicas: 1

--- a/e2e-tests/tests/upgrade/psmdb/30-change-cr.yaml
+++ b/e2e-tests/tests/upgrade/psmdb/30-change-cr.yaml
@@ -13,7 +13,7 @@ spec:
         mode: slowOp
     replicas: 1
     storage:
-      size: 1G
+      size: 1Gi
   proxy:
     type: haproxy
     replicas: 1


### PR DESCRIPTION
**Fix new PG DBs getting stuck in Unknown state after deleting a PG DB**
---
**Problem:**
EVEREST-1278

New PG DBs get stuck in the Unknown state after deleting a PG DB

**Related pull requests**

- https://github.com/percona/percona-postgresql-operator/pull/848

**Cause:**
Due to a bug in PGO v2.4.0 the PGO reconciliation loop is getting stuck after the deletion of a DB which causes any new PG DBs provisioned in Everest to be stuck in the Unknown state.

**Solution:**
Until [K8SPG-616](https://perconadev.atlassian.net/browse/K8SPG-616) is released we work around the issue by restarting the PG operator deployment after deleting a DB.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?


[K8SPG-616]: https://perconadev.atlassian.net/browse/K8SPG-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ