### PR TITLE
EVEREST-1316 Backups repos reconciliation fix

### DIFF
--- a/controllers/common/helper.go
+++ b/controllers/common/helper.go
@@ -601,8 +601,8 @@ func IsDatabaseClusterRestoreRunning(
 	return false, nil
 }
 
-// GetBackupStorageNameInPGBackrestRepo returns the name of the backup storage in the pgbackrest repo list.
-func GetBackupStorageNameInPGBackrestRepo(
+// GetRepoNameByBackupStorage returns the name of the repo that corresponds to the given backup storage
+func GetRepoNameByBackupStorage(
 	backupStorage *everestv1alpha1.BackupStorage,
 	repos []crunchyv1beta1.PGBackRestRepo,
 ) string {

--- a/controllers/common/helper.go
+++ b/controllers/common/helper.go
@@ -601,24 +601,24 @@ func IsDatabaseClusterRestoreRunning(
 	return false, nil
 }
 
-// GetBackupStorageIndexInPGBackrestRepo returns the index of the backup storage in the pgbackrest repo list.
-func GetBackupStorageIndexInPGBackrestRepo(
+// GetBackupStorageNameInPGBackrestRepo returns the name of the backup storage in the pgbackrest repo list.
+func GetBackupStorageNameInPGBackrestRepo(
 	backupStorage *everestv1alpha1.BackupStorage,
 	repos []crunchyv1beta1.PGBackRestRepo,
-) int {
-	for idx, repo := range repos {
+) string {
+	for _, repo := range repos {
 		if repo.S3 != nil &&
 			repo.S3.Bucket == backupStorage.Spec.Bucket &&
 			repo.S3.Region == backupStorage.Spec.Region &&
 			repo.S3.Endpoint == backupStorage.Spec.EndpointURL {
-			return idx
+			return repo.Name
 		}
 
 		if repo.Azure != nil && repo.Azure.Container == backupStorage.Spec.Bucket {
-			return idx
+			return repo.Name
 		}
 	}
-	return -1
+	return ""
 }
 
 // HandleUpstreamClusterCleanup handles the cleanup of the psdmb objects.

--- a/controllers/common/helper.go
+++ b/controllers/common/helper.go
@@ -601,7 +601,7 @@ func IsDatabaseClusterRestoreRunning(
 	return false, nil
 }
 
-// GetRepoNameByBackupStorage returns the name of the repo that corresponds to the given backup storage
+// GetRepoNameByBackupStorage returns the name of the repo that corresponds to the given backup storage.
 func GetRepoNameByBackupStorage(
 	backupStorage *everestv1alpha1.BackupStorage,
 	repos []crunchyv1beta1.PGBackRestRepo,

--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -845,7 +845,7 @@ func (r *DatabaseClusterBackupReconciler) reconcilePG(
 
 	// If the backup storage is not defined in the PerconaPGCluster CR, we
 	// cannot proceed
-	repoName := common.GetBackupStorageNameInPGBackrestRepo(backupStorage, pgDBCR.Spec.Backups.PGBackRest.Repos)
+	repoName := common.GetRepoNameByBackupStorage(backupStorage, pgDBCR.Spec.Backups.PGBackRest.Repos)
 	if repoName == "" {
 		return false, ErrBackupStorageUndefined
 	}

--- a/controllers/databaseclusterbackup_controller.go
+++ b/controllers/databaseclusterbackup_controller.go
@@ -845,8 +845,8 @@ func (r *DatabaseClusterBackupReconciler) reconcilePG(
 
 	// If the backup storage is not defined in the PerconaPGCluster CR, we
 	// cannot proceed
-	repoIdx := common.GetBackupStorageIndexInPGBackrestRepo(backupStorage, pgDBCR.Spec.Backups.PGBackRest.Repos)
-	if repoIdx == -1 {
+	repoName := common.GetBackupStorageNameInPGBackrestRepo(backupStorage, pgDBCR.Spec.Backups.PGBackRest.Repos)
+	if repoName == "" {
 		return false, ErrBackupStorageUndefined
 	}
 
@@ -865,7 +865,7 @@ func (r *DatabaseClusterBackupReconciler) reconcilePG(
 				BlockOwnerDeletion: pointer.ToBool(true),
 			}})
 
-			pgCR.Spec.RepoName = pgDBCR.Spec.Backups.PGBackRest.Repos[repoIdx].Name
+			pgCR.Spec.RepoName = repoName
 			pgCR.Spec.Options = []string{
 				"--type=full",
 			}

--- a/controllers/databaseclusterrestore_controller.go
+++ b/controllers/databaseclusterrestore_controller.go
@@ -465,7 +465,7 @@ func (r *DatabaseClusterRestoreReconciler) restorePG(ctx context.Context, restor
 	// PerconaPGCluster CR. If not, we requeue the restore to give the
 	// DatabaseCluster controller a chance to update the PG cluster CR.
 	// Otherwise, the restore will fail.
-	repoName := common.GetBackupStorageNameInPGBackrestRepo(backupStorage, pgDBCR.Spec.Backups.PGBackRest.Repos)
+	repoName := common.GetRepoNameByBackupStorage(backupStorage, pgDBCR.Spec.Backups.PGBackRest.Repos)
 	if repoName == "" {
 		logger.Info(
 			fmt.Sprintf("Backup storage %s is not defined in the pg cluster %s, requeuing",

--- a/controllers/databaseclusterrestore_controller.go
+++ b/controllers/databaseclusterrestore_controller.go
@@ -465,8 +465,8 @@ func (r *DatabaseClusterRestoreReconciler) restorePG(ctx context.Context, restor
 	// PerconaPGCluster CR. If not, we requeue the restore to give the
 	// DatabaseCluster controller a chance to update the PG cluster CR.
 	// Otherwise, the restore will fail.
-	repoIdx := common.GetBackupStorageIndexInPGBackrestRepo(backupStorage, pgDBCR.Spec.Backups.PGBackRest.Repos)
-	if repoIdx == -1 {
+	repoName := common.GetBackupStorageNameInPGBackrestRepo(backupStorage, pgDBCR.Spec.Backups.PGBackRest.Repos)
+	if repoName == "" {
 		logger.Info(
 			fmt.Sprintf("Backup storage %s is not defined in the pg cluster %s, requeuing",
 				backupStorageName,
@@ -486,7 +486,7 @@ func (r *DatabaseClusterRestoreReconciler) restorePG(ctx context.Context, restor
 	}
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, pgCR, func() error {
 		pgCR.Spec.PGCluster = restore.Spec.DBClusterName
-		pgCR.Spec.RepoName = pgDBCR.Spec.Backups.PGBackRest.Repos[repoIdx].Name
+		pgCR.Spec.RepoName = repoName
 		pgCR.Spec.Options, err = getPGRestoreOptions(restore.Spec.DataSource, backupBaseName)
 		return err
 	})


### PR DESCRIPTION
**Backups repos reconciliation fix**
---
**Problem:**
EVEREST-1316

Changes:

1. For backups and new schedules: first check if there is any existing repo which can be reused and only if there is none - create a new repo
2. When creating an on-demand backup, rely on the repo name but not on it's index - this approach is more reliable. 
3. Sort the repos by name. When schedules are deleted, the pg cluster might get into the state when it has [repo1, repo3, repo2], so the repos can switch places although they still pointing out to the same bucket as before. It's confusing, so from now on we always sort repos by name
4. Added tests to cover the failing cases.  

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
