### PR TITLE
EVEREST-1349 Fix DBs stuck in the "Deleting" state

### DIFF
--- a/controllers/common/consts.go
+++ b/controllers/common/consts.go
@@ -63,6 +63,10 @@ const (
 	// EverestSecretsPrefix is the prefix for secrets created by Everest.
 	EverestSecretsPrefix = "everest-secrets-"
 
+	// DBBackupCleanupFinalizer is the finalizer for cleaning up DatabaseClusterBackup.
+	// Deprecated: We keep this for backward compatibility.
+	DBBackupCleanupFinalizer = "everest.percona.com/dbb-cleanup"
+
 	// UpstreamClusterCleanupFinalizer is the finalizer for cleaning up the upstream cluster.
 	UpstreamClusterCleanupFinalizer = "everest.percona.com/upstream-cluster-cleanup"
 

--- a/controllers/providers/pg/provider.go
+++ b/controllers/providers/pg/provider.go
@@ -134,6 +134,12 @@ func (p *Provider) Status(ctx context.Context) (everestv1alpha1.DatabaseClusterS
 
 // Cleanup runs the cleanup routines and returns true if the cleanup is done.
 func (p *Provider) Cleanup(ctx context.Context, database *everestv1alpha1.DatabaseCluster) (bool, error) {
+	// Even though we no longer set the DBBackupCleanupFinalizer, we still need
+	// to handle the cleanup to ensure backward compatibility.
+	done, err := common.HandleDBBackupsCleanup(ctx, p.C, database)
+	if err != nil || !done {
+		return done, err
+	}
 	return common.HandleUpstreamClusterCleanup(ctx, p.C, database, &pgv2.PerconaPGCluster{})
 }
 

--- a/controllers/providers/psmdb/provider.go
+++ b/controllers/providers/psmdb/provider.go
@@ -160,6 +160,12 @@ func (p *Provider) Cleanup(ctx context.Context, database *everestv1alpha1.Databa
 	if err != nil {
 		return false, err
 	}
+	// Even though we no longer set the DBBackupCleanupFinalizer, we still need
+	// to handle the cleanup to ensure backward compatibility.
+	done, err := common.HandleDBBackupsCleanup(ctx, p.C, database)
+	if err != nil || !done {
+		return done, err
+	}
 	return common.HandleUpstreamClusterCleanup(ctx, p.C, database, &psmdbv1.PerconaServerMongoDB{})
 }
 

--- a/controllers/providers/pxc/provider.go
+++ b/controllers/providers/pxc/provider.go
@@ -230,6 +230,12 @@ func (p *Provider) Status(ctx context.Context) (everestv1alpha1.DatabaseClusterS
 
 // Cleanup runs the cleanup routines and returns true if the cleanup is done.
 func (p *Provider) Cleanup(ctx context.Context, database *everestv1alpha1.DatabaseCluster) (bool, error) {
+	// Even though we no longer set the DBBackupCleanupFinalizer, we still need
+	// to handle the cleanup to ensure backward compatibility.
+	done, err := common.HandleDBBackupsCleanup(ctx, p.C, database)
+	if err != nil || !done {
+		return done, err
+	}
 	return common.HandleUpstreamClusterCleanup(ctx, p.C, database, &pxcv1.PerconaXtraDBCluster{})
 }
 


### PR DESCRIPTION
**Problem:**
EVEREST-1349

DBs created with old versions of the everest-operator get stuck in the "Deleting" state

**Related pull requests**

- #428 

**Cause:**
In PR #428 we removed the dbb-cleanup finalizer because we introduced owner references that automatically delete the objects. However, DBs created with previous versions of the everest-operator will still feature the dbb-cleanup finalizer which needs to be properly handled otherwise the DB will be stuck in the "Deleting" state.

**Solution:**
Revert the removal of the dbb-backup finalizer handling.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~
