### PR TITLE
EVEREST-1354 Fix PXC resources being overwritten

### DIFF
--- a/controllers/providers/pxc/applier.go
+++ b/controllers/providers/pxc/applier.go
@@ -98,15 +98,12 @@ func (p *applier) Engine() error {
 	case everestv1alpha1.EngineSizeSmall:
 		pxc.Spec.PXC.PodSpec.LivenessProbes.TimeoutSeconds = 450
 		pxc.Spec.PXC.PodSpec.ReadinessProbes.TimeoutSeconds = 450
-		pxc.Spec.PXC.PodSpec.Resources = pxcResourceRequirementsSmall
 	case everestv1alpha1.EngineSizeMedium:
 		pxc.Spec.PXC.PodSpec.LivenessProbes.TimeoutSeconds = 451
 		pxc.Spec.PXC.PodSpec.ReadinessProbes.TimeoutSeconds = 451
-		pxc.Spec.PXC.PodSpec.Resources = pxcResourceRequirementsMedium
 	case everestv1alpha1.EngineSizeLarge:
 		pxc.Spec.PXC.PodSpec.LivenessProbes.TimeoutSeconds = 600
 		pxc.Spec.PXC.PodSpec.ReadinessProbes.TimeoutSeconds = 600
-		pxc.Spec.PXC.PodSpec.Resources = pxcResourceRequirementsLarge
 	}
 	return nil
 }

--- a/controllers/providers/pxc/applier.go
+++ b/controllers/providers/pxc/applier.go
@@ -89,9 +89,11 @@ func (p *applier) Engine() error {
 
 	if !p.DB.Spec.Engine.Resources.CPU.IsZero() {
 		pxc.Spec.PXC.PodSpec.Resources.Limits[corev1.ResourceCPU] = p.DB.Spec.Engine.Resources.CPU
+		pxc.Spec.PXC.PodSpec.Resources.Requests[corev1.ResourceCPU] = p.DB.Spec.Engine.Resources.CPU
 	}
 	if !p.DB.Spec.Engine.Resources.Memory.IsZero() {
 		pxc.Spec.PXC.PodSpec.Resources.Limits[corev1.ResourceMemory] = p.DB.Spec.Engine.Resources.Memory
+		pxc.Spec.PXC.PodSpec.Resources.Requests[corev1.ResourceMemory] = p.DB.Spec.Engine.Resources.Memory
 	}
 
 	switch p.DB.Spec.Engine.Size() {
@@ -186,6 +188,10 @@ func defaultSpec() pxcv1.PerconaXtraDBClusterSpec {
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1G"),
+						corev1.ResourceCPU:    resource.MustParse("600m"),
+					},
+					Requests: corev1.ResourceList{
 						corev1.ResourceMemory: resource.MustParse("1G"),
 						corev1.ResourceCPU:    resource.MustParse("600m"),
 					},

--- a/controllers/providers/pxc/mysqld_configs.go
+++ b/controllers/providers/pxc/mysqld_configs.go
@@ -17,8 +17,6 @@ package pxc
 
 import (
 	goversion "github.com/hashicorp/go-version"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // minVersionForOptimizedConfig is the version below which we will not apply optimized configuration.
@@ -167,42 +165,4 @@ wsrep_trx_fragment_size = 1048576
 wsrep_trx_fragment_unit = bytes
 wsrep-provider-options = evs.delayed_keep_period=PT560S;evs.stats_report_period=PT1M;gcs.fc_limit=128;gmcast.peer_timeout=PT15S;gmcast.time_wait=PT18S;evs.max_install_timeouts=5;pc.recovery=true;gcache.recover=yes;gcache.size=8989366809;evs.delay_margin=PT30S;evs.user_send_window=1024;evs.inactive_check_period=PT5S;evs.join_retrans_period=PT5S;evs.suspect_timeout=PT60S;gcs.max_packet_size=131072;pc.linger=PT60S;evs.send_window=1024;evs.inactive_timeout=PT120S;pc.announce_timeout=PT60S;
 	`
-)
-
-var ( //nolint:dupl
-	// A pxcResourceRequirementsSmall is the resource requirements for PXC for small clusters.
-	pxcResourceRequirementsSmall = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("1.61Gi"),
-			corev1.ResourceCPU:    resource.MustParse("570m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("1.7Gi"),
-			corev1.ResourceCPU:    resource.MustParse("600m"),
-		},
-	}
-
-	// A pxcResourceRequirementsMedium is the resource requirements for PXC for medium clusters.
-	pxcResourceRequirementsMedium = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("6.65Gi"),
-			corev1.ResourceCPU:    resource.MustParse("3040m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("7Gi"),
-			corev1.ResourceCPU:    resource.MustParse("3200m"),
-		},
-	}
-
-	// A pxcResourceRequirementsLarge is the resource requirements for PXC for large clusters.
-	pxcResourceRequirementsLarge = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("26.6Gi"),
-			corev1.ResourceCPU:    resource.MustParse("3040m"),
-		},
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("28Gi"),
-			corev1.ResourceCPU:    resource.MustParse("3200m"),
-		},
-	}
 )

--- a/e2e-tests/tests/core/pxc/10-assert.yaml
+++ b/e2e-tests/tests/core/pxc/10-assert.yaml
@@ -55,6 +55,9 @@ spec:
       limits:
         cpu: 600m
         memory: 1G
+      requests:
+        cpu: 600m
+        memory: 1G
     serviceType: ClusterIP
     sidecarResources: {}
     size: 3

--- a/e2e-tests/tests/core/pxc/30-assert.yaml
+++ b/e2e-tests/tests/core/pxc/30-assert.yaml
@@ -52,6 +52,9 @@ spec:
       limits:
         cpu: 600m
         memory: 1G
+      requests:
+        cpu: 600m
+        memory: 1G
     serviceType: ClusterIP
     sidecarResources: {}
     size: 3

--- a/e2e-tests/tests/core/pxc/50-assert.yaml
+++ b/e2e-tests/tests/core/pxc/50-assert.yaml
@@ -54,6 +54,9 @@ spec:
       limits:
         cpu: 600m
         memory: 1G
+      requests:
+        cpu: 600m
+        memory: 1G
     serviceType: ClusterIP
     sidecarResources: {}
     size: 1

--- a/e2e-tests/tests/core/pxc/60-assert.yaml
+++ b/e2e-tests/tests/core/pxc/60-assert.yaml
@@ -54,6 +54,9 @@ spec:
       limits:
         cpu: 600m
         memory: 1G
+      requests:
+        cpu: 600m
+        memory: 1G
     serviceType: ClusterIP
     sidecarResources: {}
     size: 3


### PR DESCRIPTION
**Problem:**
EVEREST-1354

PXC pod's resource limits were being overwritten.

**Related pull requests**

- #309

**Cause:**
We were setting preset resource limits values based on the specified memory. This completely overwrites any custom value. 

**Solution:**
* Don't overwrite the resources limits set by the users
* Set the requests to equal the limits

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [x] Is an Integration test/test case added for the new feature/change?
- ~[ ] Are unit tests added where appropriate?~
