### PR TITLE
EVEREST-1264 | Fix Secret reconciliation for MonitoringConfig controller

### DIFF
--- a/controllers/monitoringconfig_controller.go
+++ b/controllers/monitoringconfig_controller.go
@@ -348,6 +348,12 @@ func (r *MonitoringConfigReconciler) cleanupSecrets(ctx context.Context, mc *eve
 // reconcileSecret copies the source MonitoringConfig secret onto the monitoring namespace.
 // Returns the name of the newly created/updated secret.
 func (r *MonitoringConfigReconciler) reconcileSecret(ctx context.Context, mc *everestv1alpha1.MonitoringConfig) (string, error) {
+	// If the MonitoringConfig is in the monitoring namespace, we don't have to do any additional work.
+	// Use the secret as-is.
+	if mc.GetNamespace() == r.monitoringNamespace {
+		return mc.Spec.CredentialsSecretName, nil
+	}
+
 	// Get the secret in the MonitoringConfig namespace.
 	secret := &corev1.Secret{}
 	err := r.Get(ctx, types.NamespacedName{


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1264

MonitoringConfigs stopped working after https://github.com/percona/everest-operator/pull/463 was merged.

**Cause:**
https://github.com/percona/everest-operator/pull/463 changes the way how MonitoringConfigs are referenced by the DB. Earlier, MonitoringConfigs and its Secret were created in the same namespace as the VMAgent, i.e, `everest-monitoring.` With https://github.com/percona/everest-operator/pull/463, MonitoringConfigs and its Secret are now created in the DB namespace, and VMAgent can no longer reference the secret since it belongs to a different namespace.

**Solution:**

- Add additional logic to copy the Secret to the `everest-monitoring` namespace
- Secret is automatically cleaned up with the help of a finalizer

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
