### PR TITLE
EVEREST-1305 Apply default affinity rules for mongos

### DIFF
--- a/controllers/providers/psmdb/applier.go
+++ b/controllers/providers/psmdb/applier.go
@@ -196,6 +196,11 @@ func (p *applier) Proxy() error {
 		}
 		psmdb.Spec.Sharding.Mongos = &psmdbv1.MongosSpec{
 			Size: size,
+			MultiAZ: psmdbv1.MultiAZ{
+				Affinity: &psmdbv1.PodAffinity{
+					Advanced: common.DefaultAffinitySettings().DeepCopy(),
+				},
+			},
 		}
 	}
 	err := p.exposeShardedCluster(&psmdb.Spec.Sharding.Mongos.Expose)


### PR DESCRIPTION
**Apply default affinity rules for mongos**
---
**Problem:**
EVEREST-1305

DB can stuck with:
```
 mongos:
    message: '0/1 nodes are available: 1 node(s) didn''t match pod anti-affinity rules.
```

**Cause:**
If there are no rules applied to `.spec.sharding.mongos`, then the `requiredDuringSchedulingIgnoredDuringExecution` with `topologyKey: kubernetes.io/hostname` is applied by the operator. 

**Solution:**
Apply the default `preferredDuringSchedulingIgnoredDuringExecution` rule for `.spec.sharding.mongos` as Everest does for other pods. The rule is not that strict and schedules pods to the different nodes _if possible_

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
