### PR TITLE
EVEREST-1414 | DBC controller should not modify labels set by other operators

### DIFF
--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -410,6 +410,7 @@ outer:
 	}
 
 	if !maps.Equal(updated, current) {
+		database.SetLabels(updated)
 		return r.Update(ctx, database)
 	}
 	return nil


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1414

Everest operator removes any extra labels that are not managed by it. This is a bit of a problem when the Everest resources are managed by anther operator/entity. For example, when deploying with ArgoCD, it adds an extra `app.kubernetes.io/instance` label, however Everest operator removes it.

**Cause:**

The `reconcileLabels` logic is written in such a way that it keeps only those labels that the Everest operator needs.

**Solution:**
Re-write the code so that existing labels are merged with the ones Everest needs.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
