### PR TITLE
EVEREST-1415 Deleting status fix

### DIFF
--- a/controllers/common/helper.go
+++ b/controllers/common/helper.go
@@ -665,8 +665,6 @@ func HandleUpstreamClusterCleanup(
 			}
 			return false, err
 		}
-		controllerutil.RemoveFinalizer(database, UpstreamClusterCleanupFinalizer)
-		return true, c.Update(ctx, database)
 	}
 	return true, nil
 }

--- a/e2e-tests/tests/upgrade/pg/90-delete-clusters.yaml
+++ b/e2e-tests/tests/upgrade/pg/90-delete-clusters.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 commands:
-  - command: kubectl -n $NAMESPACE delete db test-pg-cluster
   - command: kubectl patch postgresclusters test-pg-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+  - command: kubectl -n $NAMESPACE delete db test-pg-cluster
     ignoreFailure: true

--- a/e2e-tests/tests/upgrade/psmdb/90-delete-cluster.yaml
+++ b/e2e-tests/tests/upgrade/psmdb/90-delete-cluster.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 commands:
-  - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
   - command: kubectl patch psmdb test-psmdb-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+  - command: kubectl -n $NAMESPACE delete db test-psmdb-cluster
     ignoreFailure: true

--- a/e2e-tests/tests/upgrade/pxc/90-delete-cluster.yaml
+++ b/e2e-tests/tests/upgrade/pxc/90-delete-cluster.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 commands:
-  - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
   - command: kubectl patch pxc test-pxc-cluster -n $NAMESPACE -p '{"metadata":{"finalizers":null}}' --type merge
+  - command: kubectl -n $NAMESPACE delete db test-pxc-cluster
     ignoreFailure: true


### PR DESCRIPTION
**Deleting status fix**
---
**Problem:**
EVEREST-1415

Everest cluster does not follow the further upstream cluster statuses after deletion. As a result if the upstream cluster deletion takes long (for example, a sharded psmdb cluster with 5 nodes), the psmdb cluster hangs in the “stopping“ state but in Everest there is no DatabaseCluster shown anymore as if it is deleted. 

**Cause:**
Everest has this `everest.percona.com/upstream-cluster-cleanup` finalizer which ensures that the upstream cluster deletion is triggered and after this deletion Everest removes the finalizer  which unblocks the DatabaseCluster CR deletion. So the DatabaseCluster CR is deleted but the upstream psmdb still exists in the “stopping“ state. 

**Solution:**
Do not remove the `everest.percona.com/upstream-cluster-cleanup` finalizer until the upstream cluster is indeed deleted. 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
