### PR TITLE
EVEREST-1424 | Cannot apply PXC resource settings after adding restart protection mechanism

### DIFF
--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -356,6 +356,8 @@ type DatabaseClusterSpec struct {
 
 // DatabaseClusterStatus defines the observed state of DatabaseCluster.
 type DatabaseClusterStatus struct {
+	// ObservedGeneration is the most recent generation observed for this DatabaseCluster.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// Status is the status of the cluster
 	Status AppState `json:"status,omitempty"`
 	// Hostname is the hostname where the cluster can be reached

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-08-29T09:22:49Z"
+    createdAt: "2024-09-10T06:34:46Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: everest-operator.v0.0.0

--- a/bundle/manifests/everest.percona.com_databaseclusters.yaml
+++ b/bundle/manifests/everest.percona.com_databaseclusters.yaml
@@ -418,6 +418,11 @@ spec:
               message:
                 description: Message is extra information about the cluster
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this DatabaseCluster.
+                format: int64
+                type: integer
               port:
                 description: Port is the port where the cluster can be reached
                 format: int32

--- a/config/crd/bases/everest.percona.com_databaseclusters.yaml
+++ b/config/crd/bases/everest.percona.com_databaseclusters.yaml
@@ -418,6 +418,11 @@ spec:
               message:
                 description: Message is extra information about the cluster
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this DatabaseCluster.
+                format: int64
+                type: integer
               port:
                 description: Port is the port where the cluster can be reached
                 format: int32

--- a/controllers/databasecluster_controller.go
+++ b/controllers/databasecluster_controller.go
@@ -191,6 +191,7 @@ func (r *DatabaseClusterReconciler) reconcileDB(
 		return ctrl.Result{}, err
 	}
 	db.Status = status
+	db.Status.ObservedGeneration = db.GetGeneration()
 	if err := r.Client.Status().Update(ctx, db); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/providers/pxc/applier.go
+++ b/controllers/providers/pxc/applier.go
@@ -95,10 +95,13 @@ func (p *applier) Engine() error {
 		pxc.Spec.PXC.PodSpec.Resources.Limits[corev1.ResourceMemory] = p.DB.Spec.Engine.Resources.Memory
 		pxc.Spec.PXC.PodSpec.Resources.Requests[corev1.ResourceMemory] = p.DB.Spec.Engine.Resources.Memory
 	}
+	hasDBSpecChanged := func() bool {
+		return p.DB.Status.ObservedGeneration > 0 && p.DB.Status.ObservedGeneration != p.DB.Generation
+	}
 	// We preserve the settings for existing DBs, otherwise restarts are seen when upgrading Everest.
 	// TODO: Remove this once we figure out how to apply such spec changes without automatic restarts.
 	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
-	if p.DB.Status.Status == everestv1alpha1.AppStateReady {
+	if p.DB.Status.Status == everestv1alpha1.AppStateReady && !hasDBSpecChanged() {
 		pxc.Spec.PXC.PodSpec.Resources = p.currentPerconaXtraDBClusterSpec.PXC.PodSpec.Resources
 	}
 
@@ -116,14 +119,11 @@ func (p *applier) Engine() error {
 	p.PerconaXtraDBCluster.Spec.PXC.PodSpec.Affinity = &pxcv1.PodAffinity{
 		Advanced: common.DefaultAffinitySettings().DeepCopy(),
 	}
-	hasDBSpecChanged := func() bool {
-		return p.DB.Status.ObservedGeneration > 0 && p.DB.Status.ObservedGeneration != p.DB.Generation
-	}
 	// We preserve the settings for existing DBs, otherwise restarts are seen when upgrading Everest.
 	// Additionally, we also need to check for the spec changes, otherwise the user can never voluntarily change the resource setting.
 	// TODO: Remove this once we figure out how to apply such spec changes without automatic restarts.
 	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
-	if p.DB.Status.Status == everestv1alpha1.AppStateReady && !hasDBSpecChanged() {
+	if p.DB.Status.Status == everestv1alpha1.AppStateReady {
 		pxc.Spec.PXC.PodSpec.Affinity = p.currentPerconaXtraDBClusterSpec.PXC.Affinity
 	}
 	return nil

--- a/controllers/providers/pxc/applier.go
+++ b/controllers/providers/pxc/applier.go
@@ -99,6 +99,7 @@ func (p *applier) Engine() error {
 		return p.DB.Status.ObservedGeneration > 0 && p.DB.Status.ObservedGeneration != p.DB.Generation
 	}
 	// We preserve the settings for existing DBs, otherwise restarts are seen when upgrading Everest.
+	// Additionally, we also need to check for the spec changes, otherwise the user can never voluntarily change the resource setting.
 	// TODO: Remove this once we figure out how to apply such spec changes without automatic restarts.
 	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
 	if p.DB.Status.Status == everestv1alpha1.AppStateReady && !hasDBSpecChanged() {
@@ -120,7 +121,6 @@ func (p *applier) Engine() error {
 		Advanced: common.DefaultAffinitySettings().DeepCopy(),
 	}
 	// We preserve the settings for existing DBs, otherwise restarts are seen when upgrading Everest.
-	// Additionally, we also need to check for the spec changes, otherwise the user can never voluntarily change the resource setting.
 	// TODO: Remove this once we figure out how to apply such spec changes without automatic restarts.
 	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
 	if p.DB.Status.Status == everestv1alpha1.AppStateReady {

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -759,6 +759,10 @@ spec:
               message:
                 description: Message is extra information about the cluster
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed for this DatabaseCluster.
+                format: int64
+                type: integer
               port:
                 description: Port is the port where the cluster can be reached
                 format: int32


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1424

Cannot update PXC resource settings after adding the restart protection mechanism in https://perconadev.atlassian.net/browse/EVEREST-1424

- https://perconadev.atlassian.net/browse/EVEREST-1424

For more details, see comment https://github.com/percona/everest-operator/pull/511#discussion_r1751444476

**Cause:**

In the above mentioned PR, the resource settings for PXC are preserved if the DB is in running state. This means, that while there will not be any restarts when ugprading to 1.2.0, a user also cannot update these settings because the DB is running, and the older settings are preserved/overwritten.

**Solution:**

Add an additional check to detect when the DB spec may have potentially changed. We do this by tracking `.metadata.Generation`

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
