### PR TITLE
EVEREST-1523 add required PG extensions image field

### DIFF
--- a/controllers/providers/pg/applier.go
+++ b/controllers/providers/pg/applier.go
@@ -137,6 +137,17 @@ func (p *applier) Engine() error {
 	if p.DB.Status.Status == everestv1alpha1.AppStateReady {
 		pg.Spec.InstanceSets[0].Affinity = p.currentPGSpec.InstanceSets[0].Affinity
 	}
+
+	image, err := common.GetOperatorImage(p.ctx, p.C, types.NamespacedName{
+		Name:      common.PGDeploymentName,
+		Namespace: p.DB.GetNamespace(),
+	})
+	if err != nil {
+		return err
+	}
+	pg.Spec.Extensions = pgv2.ExtensionsSpec{
+		Image: image,
+	}
 	return nil
 }
 


### PR DESCRIPTION
**Problem:**
EVEREST-1523

Upgrading to PGO v2.4.1 fails.

**Cause:**
PGO v2.4.1 changed the `.spec.extensions.image` to be required so CRs without it were causing the OLM install plan to fail.

**Solution:**
Even though `.spec.extensions` is set to be optional, we use the golang struct to generate the default PG spec and since `.spec.extensions` is a value and not a pointer we generate an empty struct which violates the required restriction on the `image` field. By setting this field we ensure that by the time users trigger an upgrade to v2.4.1 the existing CRs already have the field and thus the install plan succeeds.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- ~[ ] Is an Integration test/test case added for the new feature/change?~
- ~[ ] Are unit tests added where appropriate?~
