### PR TITLE
EVEREST-1434 | Fix PG DB restarts after upgrading PGO to 2.4.1

### DIFF
--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -49,6 +49,8 @@ const (
 	AppStateRestoring AppState = "restoring"
 	// AppStateDeleting is a deleting state.
 	AppStateDeleting AppState = "deleting"
+	// AppStateNew represents a newly created cluster that has not yet been reconciled.
+	AppStateNew AppState = ""
 
 	// ExposeTypeInternal is an internal expose type.
 	ExposeTypeInternal ExposeType = "internal"

--- a/controllers/providers/pg/applier.go
+++ b/controllers/providers/pg/applier.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go/version"
 	"net/url"
 	"path/filepath"
 	"regexp"
@@ -131,10 +132,12 @@ func (p *applier) Engine() error {
 		},
 	}
 	pg.Spec.InstanceSets[0].Affinity = common.DefaultAffinitySettings().DeepCopy()
-	// We preserve the settings for existing DBs, otherwise restarts are seen when upgrading Everest.
+	// This is a temporary workaround to apply new affinity settings without restarting, when upgrading
+	// the Everest operator (to 1.2.0) and the PG operator (to 2.4.1)
 	// TODO: Remove this once we figure out how to apply such spec changes without automatic restarts.
 	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
-	if p.DB.Status.Status == everestv1alpha1.AppStateReady {
+	crVersion := p.currentPGSpec.CRVersion
+	if p.DB.Status.Status == everestv1alpha1.AppStateReady && version.Compare(crVersion, "2.4.1") >= 0 {
 		pg.Spec.InstanceSets[0].Affinity = p.currentPGSpec.InstanceSets[0].Affinity
 	}
 
@@ -203,10 +206,12 @@ func (p *applier) Proxy() error {
 		},
 	}
 	pg.Spec.Proxy.PGBouncer.Affinity = common.DefaultAffinitySettings().DeepCopy()
-	// We preserve the settings for existing DBs, otherwise restarts are seen when upgrading Everest.
+	// This is a temporary workaround to apply new affinity settings without restarting, when upgrading
+	// the Everest operator (to 1.2.0) and the PG operator (to 2.4.1)
 	// TODO: Remove this once we figure out how to apply such spec changes without automatic restarts.
 	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
-	if p.DB.Status.Status == everestv1alpha1.AppStateReady {
+	crVersion := p.currentPGSpec.CRVersion
+	if p.DB.Status.Status == everestv1alpha1.AppStateReady && version.Compare(crVersion, "2.4.1") >= 0 {
 		pg.Spec.Proxy.PGBouncer.Affinity = p.currentPGSpec.Proxy.PGBouncer.Affinity
 	}
 

--- a/controllers/providers/pg/applier.go
+++ b/controllers/providers/pg/applier.go
@@ -138,7 +138,7 @@ func (p *applier) Engine() error {
 	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
 	crVersion := goversion.Must(goversion.NewVersion(pg.Spec.CRVersion))
 	if p.DB.Status.Status == everestv1alpha1.AppStateReady &&
-		crVersion.GreaterThanOrEqual(goversion.Must(goversion.NewVersion("2.4.1"))) {
+		crVersion.LessThan(goversion.Must(goversion.NewVersion("2.4.1"))) {
 		pg.Spec.InstanceSets[0].Affinity = p.currentPGSpec.InstanceSets[0].Affinity
 	}
 
@@ -213,7 +213,7 @@ func (p *applier) Proxy() error {
 	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
 	crVersion := goversion.Must(goversion.NewVersion(pg.Spec.CRVersion))
 	if p.DB.Status.Status == everestv1alpha1.AppStateReady &&
-		crVersion.GreaterThanOrEqual(goversion.Must(goversion.NewVersion("2.4.1"))) {
+		crVersion.LessThan(goversion.Must(goversion.NewVersion("2.4.1"))) {
 		pg.Spec.Proxy.PGBouncer.Affinity = p.currentPGSpec.Proxy.PGBouncer.Affinity
 	}
 

--- a/controllers/providers/pg/applier.go
+++ b/controllers/providers/pg/applier.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go/version"
 	"net/url"
 	"path/filepath"
 	"regexp"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/AlekSi/pointer"
 	"github.com/go-ini/ini"
+	goversion "github.com/hashicorp/go-version"
 	pgv2 "github.com/percona/percona-postgresql-operator/pkg/apis/pgv2.percona.com/v2"
 	crunchyv1beta1 "github.com/percona/percona-postgresql-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -136,8 +136,9 @@ func (p *applier) Engine() error {
 	// the Everest operator (to 1.2.0) and the PG operator (to 2.4.1)
 	// TODO: Remove this once we figure out how to apply such spec changes without automatic restarts.
 	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
-	crVersion := p.currentPGSpec.CRVersion
-	if p.DB.Status.Status == everestv1alpha1.AppStateReady && version.Compare(crVersion, "2.4.1") >= 0 {
+	crVersion := goversion.Must(goversion.NewVersion(pg.Spec.CRVersion))
+	if p.DB.Status.Status == everestv1alpha1.AppStateReady &&
+		crVersion.GreaterThanOrEqual(goversion.Must(goversion.NewVersion("2.4.1"))) {
 		pg.Spec.InstanceSets[0].Affinity = p.currentPGSpec.InstanceSets[0].Affinity
 	}
 
@@ -210,8 +211,9 @@ func (p *applier) Proxy() error {
 	// the Everest operator (to 1.2.0) and the PG operator (to 2.4.1)
 	// TODO: Remove this once we figure out how to apply such spec changes without automatic restarts.
 	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
-	crVersion := p.currentPGSpec.CRVersion
-	if p.DB.Status.Status == everestv1alpha1.AppStateReady && version.Compare(crVersion, "2.4.1") >= 0 {
+	crVersion := goversion.Must(goversion.NewVersion(pg.Spec.CRVersion))
+	if p.DB.Status.Status == everestv1alpha1.AppStateReady &&
+		crVersion.GreaterThanOrEqual(goversion.Must(goversion.NewVersion("2.4.1"))) {
 		pg.Spec.Proxy.PGBouncer.Affinity = p.currentPGSpec.Proxy.PGBouncer.Affinity
 	}
 

--- a/controllers/providers/pg/applier.go
+++ b/controllers/providers/pg/applier.go
@@ -132,13 +132,11 @@ func (p *applier) Engine() error {
 		},
 	}
 	pg.Spec.InstanceSets[0].Affinity = common.DefaultAffinitySettings().DeepCopy()
-	// This is a temporary workaround to apply new affinity settings without restarting, when upgrading
-	// the Everest operator (to 1.2.0) and the PG operator (to 2.4.1)
-	// TODO: Remove this once we figure out how to apply such spec changes without automatic restarts.
-	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
+	// New affinity settings (added in 1.2.0) must be applied only when PG is upgraded to 2.4.1.
+	// This is a temporary workaround to make sure we can make this change without an automatic restart.
+	// TODO: fix this once https://perconadev.atlassian.net/browse/EVEREST-1413 is addressed.
 	crVersion := goversion.Must(goversion.NewVersion(pg.Spec.CRVersion))
-	if p.DB.Status.Status == everestv1alpha1.AppStateReady &&
-		crVersion.LessThan(goversion.Must(goversion.NewVersion("2.4.1"))) {
+	if crVersion.LessThan(goversion.Must(goversion.NewVersion("2.4.1"))) {
 		pg.Spec.InstanceSets[0].Affinity = p.currentPGSpec.InstanceSets[0].Affinity
 	}
 
@@ -207,13 +205,11 @@ func (p *applier) Proxy() error {
 		},
 	}
 	pg.Spec.Proxy.PGBouncer.Affinity = common.DefaultAffinitySettings().DeepCopy()
-	// This is a temporary workaround to apply new affinity settings without restarting, when upgrading
-	// the Everest operator (to 1.2.0) and the PG operator (to 2.4.1)
-	// TODO: Remove this once we figure out how to apply such spec changes without automatic restarts.
-	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
+	// New affinity settings (added in 1.2.0) must be applied only when PG is upgraded to 2.4.1.
+	// This is a temporary workaround to make sure we can make this change without an automatic restart.
+	// TODO: fix this once https://perconadev.atlassian.net/browse/EVEREST-1413 is addressed.
 	crVersion := goversion.Must(goversion.NewVersion(pg.Spec.CRVersion))
-	if p.DB.Status.Status == everestv1alpha1.AppStateReady &&
-		crVersion.LessThan(goversion.Must(goversion.NewVersion("2.4.1"))) {
+	if crVersion.LessThan(goversion.Must(goversion.NewVersion("2.4.1"))) {
 		pg.Spec.Proxy.PGBouncer.Affinity = p.currentPGSpec.Proxy.PGBouncer.Affinity
 	}
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1434

PG DBs restart after upgrading the PG operator to 2.4.1

**Cause:**
- In https://github.com/percona/everest-operator/pull/511, we added a workaround to ensure that the new affinity settings are applied only on those clusters which are in the initialising state.
- Due to a new change added in PGO 2.4.1, PG DBs briefly go into the "initialising" state even though no pods are actually restart.
- Due to this brief change in state, Everest operator applies the new affinity settings on the DB pods, which results in a complete restart.

**Solution:**
- Do not depend on this "initialising" state
- Apply new affinity settings only if the following conditions are met
  - the cluster is a new cluster (i.e, no state reported yet)
  - for existing clusters, CRVersion should be >= 2.4.1

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
