### PR TITLE
Fix broken docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY pkg/ pkg/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command


### PR DESCRIPTION
A new package was added in https://github.com/percona/everest-operator/pull/534 due to which docker builds were left broken. This PR fixes the Dockerfile