### PR TITLE
EVEREST-1511 | Restart operator pod if new DB CRDs are installed

### DIFF
--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-10-04T11:13:45Z"
+    createdAt: "2024-10-09T06:03:54Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: everest-operator.v0.0.0
@@ -161,6 +161,12 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - delete
         - apiGroups:
           - ""
           resources:
@@ -398,6 +404,10 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 image: docker.io/perconalab/everest-operator:0.0.0
                 livenessProbe:
                   httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -107,5 +107,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,6 +15,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/controllers/databaseengine_controller.go
+++ b/controllers/databaseengine_controller.go
@@ -18,12 +18,16 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 	"slices"
 	"strings"
 	"time"
 
 	opfwv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	pgv2 "github.com/percona/percona-postgresql-operator/pkg/apis/pgv2.percona.com/v2"
+	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	pxcv1 "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	"golang.org/x/mod/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -61,11 +65,18 @@ var operatorEngine = map[string]everestv1alpha1.EngineType{
 	common.PGDeploymentName:    everestv1alpha1.DatabaseEnginePostgresql,
 }
 
+var operatorEngineTypeToCRDGroup = map[everestv1alpha1.EngineType]string{
+	everestv1alpha1.DatabaseEnginePXC:        pxcv1.SchemeGroupVersion.Group,
+	everestv1alpha1.DatabaseEnginePSMDB:      psmdbv1.SchemeGroupVersion.Group,
+	everestv1alpha1.DatabaseEnginePostgresql: pgv2.GroupVersion.Group,
+}
+
 // DatabaseEngineReconciler reconciles a DatabaseEngine object.
 type DatabaseEngineReconciler struct {
 	client.Client
 	Scheme         *runtime.Scheme
 	versionService *version.Service
+	podSelf        corev1.ObjectReference // reference to self pod.
 }
 
 //+kubebuilder:rbac:groups=everest.percona.com,resources=databaseengines,verbs=get;list;watch;create;update;patch;delete
@@ -74,6 +85,7 @@ type DatabaseEngineReconciler struct {
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=installplans,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=pods,verbs=delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -177,9 +189,52 @@ func (r *DatabaseEngineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
+	if requeue, err := r.restartIfNeeded(ctx); err != nil {
+		return ctrl.Result{}, err
+	} else if requeue {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	return ctrl.Result{
 		RequeueAfter: timeUntilUnlock,
 	}, nil
+}
+
+func (r *DatabaseEngineReconciler) restartIfNeeded(ctx context.Context) (bool, error) {
+	dbEngines := &everestv1alpha1.DatabaseEngineList{}
+	if err := r.List(ctx, dbEngines); err != nil {
+		return false, fmt.Errorf("failed to list DatabaseEngines: %w", err)
+	}
+	unregistered := 0
+	for _, dbEngine := range dbEngines.Items {
+		// Wait for all engines to be come to a stable state first, to avoid unnecessary restarts.
+		if dbEngine.Status.State == "" ||
+			dbEngine.Status.State == everestv1alpha1.DBEngineStateInstalling ||
+			dbEngine.Status.State == everestv1alpha1.DBEngineStateUpgrading {
+			return true, nil
+		}
+		if dbEngine.Status.State == everestv1alpha1.DBEngineStateNotInstalled {
+			continue
+		}
+		group, found := operatorEngineTypeToCRDGroup[dbEngine.Spec.Type]
+		if !found {
+			return false, fmt.Errorf("unknown engine type '%s'", dbEngine.Spec.Type)
+		}
+		// Ideally we would like to check if the operator is instead watching those CRs,
+		// but since that's tricky to do, it would be sufficient to check if the group is registered.
+		// We would not watch the CRs if the group is not registered.
+		if !r.Scheme.IsGroupRegistered(group) {
+			unregistered++
+		}
+	}
+	// There's an engine whose CRs are not registered in our operator, so we will restart.
+	// Restarting will re-trigger the setup and update the schemes and watches.
+	if unregistered > 0 {
+		return false, r.Delete(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: r.podSelf.Name, Namespace: r.podSelf.Namespace},
+		})
+	}
+	return false, nil
 }
 
 func (r *DatabaseEngineReconciler) reconcileOperatorUpgradeStatus(
@@ -440,7 +495,8 @@ func (r *DatabaseEngineReconciler) ensureDBEnginesInNamespaces(ctx context.Conte
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *DatabaseEngineReconciler) SetupWithManager(mgr ctrl.Manager, namespaces []string) error {
+func (r *DatabaseEngineReconciler) SetupWithManager(mgr ctrl.Manager, selfPodRef corev1.ObjectReference, namespaces []string) error {
+	r.podSelf = selfPodRef
 	if _, err := r.ensureDBEnginesInNamespaces(context.Background(), namespaces); err != nil {
 		return err
 	}

--- a/controllers/databaseengine_controller.go
+++ b/controllers/databaseengine_controller.go
@@ -202,6 +202,7 @@ func (r *DatabaseEngineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 // restartIfNeeded checks if the operator pod needs to be restarted.
 // It does so by checking if there are any running DBEngines whose CRDs are not registered with the operator.
+// Returns: [requeue(bool), error]
 func (r *DatabaseEngineReconciler) restartIfNeeded(ctx context.Context) (bool, error) {
 	if r.podSelf.Name == "" || r.podSelf.Namespace == "" {
 		return false, nil
@@ -212,7 +213,8 @@ func (r *DatabaseEngineReconciler) restartIfNeeded(ctx context.Context) (bool, e
 	}
 	unregistered := 0
 	for _, dbEngine := range dbEngines.Items {
-		// Wait for all engines to be come to a stable state first, to avoid unnecessary restarts.
+		// Wait until all DB engines are either installed/not installed.
+		// This way we can avoid redundant restarts.
 		if dbEngine.Status.State == "" ||
 			dbEngine.Status.State == everestv1alpha1.DBEngineStateInstalling ||
 			dbEngine.Status.State == everestv1alpha1.DBEngineStateUpgrading {

--- a/controllers/databaseengine_controller.go
+++ b/controllers/databaseengine_controller.go
@@ -202,7 +202,7 @@ func (r *DatabaseEngineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 // restartIfNeeded checks if the operator pod needs to be restarted.
 // It does so by checking if there are any running DBEngines whose CRDs are not registered with the operator.
-// Returns: [requeue(bool), error]
+// Returns: [requeue(bool), error].
 func (r *DatabaseEngineReconciler) restartIfNeeded(ctx context.Context) (bool, error) {
 	if r.podSelf.Name == "" || r.podSelf.Namespace == "" {
 		return false, nil

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -1188,6 +1188,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
@@ -1537,6 +1543,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: docker.io/perconalab/everest-operator:0.0.0
         livenessProbe:
           httpGet:


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
https://github.com/percona/everest-operator/pull/534 provides a way to dynamically watch namespaces based on labels, rather than setting the `DB_NAMESPACES` var. However, using this mechanism causes the DB reconciliation to get stuck.

**Cause:**

When bootstrapping the various controllers, we add watches to the DB CRs only if the CRDs exist first. This step happens only once, before the controller is started. With https://github.com/percona/everest-operator/pull/534, we're now allowed to start the operator without the DB namespaces. This means that when the controller starts, none of the DB CRDs exist, and as a result, the controllers are never watching the DB CRs.

This did not happen earlier because when you update the `DB_NAMESPACES` var, it leads to  a restart anyway, and hence all the controllers get setup again with the new watchers.

**Solution:**

This PR adds some code to inspect the DB engines and see if their corresponding CRDs are registered to the scheme. If it finds a DB engine whose scheme is not registered, then it restarts its own pod.

This is not the most elegant solution, but the simplest one with the least amount of code. A better solution would be to create a parent controller for DB, DBC and DBB, which watches for DBEngines, and dynamically creates a controller for each engine type. But this would significantly increase the scope of this work, so will this option out for now.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
