### PR TITLE
[BUGFIX] operator panics when PXC memory size is less than 2G

### DIFF
--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -99,8 +99,6 @@ const (
 	EngineSizeMedium EngineSize = "medium"
 	// EngineSizeLarge represents a large engine size.
 	EngineSizeLarge EngineSize = "large"
-	// EngineSizeUnknown represents an unknown engine size.
-	EngineSizeUnknown EngineSize = "unknown"
 )
 
 // Applier provides methods for specifying how to apply a DatabaseCluster CR
@@ -172,11 +170,7 @@ func (e Engine) Size() EngineSize {
 	if m.Cmp(MemoryMediumSize) >= 0 {
 		return EngineSizeMedium
 	}
-	// mem >= Small
-	if m.Cmp(MemorySmallSize) >= 0 {
-		return EngineSizeSmall
-	}
-	return EngineSizeUnknown
+	return EngineSizeSmall
 }
 
 // ExposeType is the expose type.


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1560

Operator panics when the PXC node size is less than 2G

**Cause:**
There is a `Size()` method which is used to determine the size of the cluster based on the memory. When the memory is less than 2G, it returns an `Unknown` size, due to which the resources field (map) is not initialized. Later, the code tries to assign a value to this nil pointer, which leads to a panic.

**Solution:**
Remove this `Unknown` constant, it should return `Small` as the default.

**CHECKLIST**
---
**Jira**
- [x ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
