### PR TITLE
EVEREST-1585 | Remove system namespaces from namespace filter

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,8 +149,7 @@ func main() {
 	// We filter namespaces only if no DBNamespaces are defined.
 	if len(dbNamespaces) == 0 {
 		common.DefaultNamespaceFilter = &predicates.NamespaceFilter{
-			AllowNamespaces: []string{cfg.SystemNamespace, cfg.MonitoringNamespace}, // system namespaces, always allow.
-			MatchLabels:     cfg.NamespaceLabels,
+			MatchLabels: cfg.NamespaceLabels,
 			GetNamespace: func(ctx context.Context, name string) (*corev1.Namespace, error) {
 				namespace := &corev1.Namespace{}
 				if err := mgr.GetClient().Get(ctx, types.NamespacedName{Name: name}, namespace); err != nil {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1585

DBEngines are created in everest-system and everest-monitoring namespaces

**Cause:**
In https://github.com/percona/everest-operator/pull/534 we introduced a new mechanism to reconcile DB namespaces using label filters and eliminating the need for manually setting the DB_NAMESPACES env variable. However, this filter had the system namespaces hard-coded to always allow them. As a result, the DBEngines controller always created the DBEngines in those namespaces. 

**Solution:**
Remove the hard-coded system namespaces from the filter. 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
