### PR TITLE
EVEREST-1598 Update pbm startingStatus interval

### DIFF
--- a/controllers/providers/psmdb/applier.go
+++ b/controllers/providers/psmdb/applier.go
@@ -563,8 +563,10 @@ func (p *applier) genPSMDBBackupSpec() (psmdbv1.BackupSpec, error) {
 		PITR: psmdbv1.PITRSpec{
 			Enabled: database.Spec.Backup.PITR.Enabled,
 		},
-		Configuration: psmdbv1.BackupConfig{BackupOptions: &psmdbv1.BackupOptions{
-			Timeouts: &psmdbv1.BackupTimeouts{Starting: pointer.ToUint32(120)}},
+		Configuration: psmdbv1.BackupConfig{
+			BackupOptions: &psmdbv1.BackupOptions{
+				Timeouts: &psmdbv1.BackupTimeouts{Starting: pointer.ToUint32(120)},
+			},
 		},
 
 		// XXX: Remove this once templates will be available

--- a/controllers/providers/psmdb/applier.go
+++ b/controllers/providers/psmdb/applier.go
@@ -563,6 +563,9 @@ func (p *applier) genPSMDBBackupSpec() (psmdbv1.BackupSpec, error) {
 		PITR: psmdbv1.PITRSpec{
 			Enabled: database.Spec.Backup.PITR.Enabled,
 		},
+		Configuration: psmdbv1.BackupConfig{BackupOptions: &psmdbv1.BackupOptions{
+			Timeouts: &psmdbv1.BackupTimeouts{Starting: pointer.ToUint32(120)}},
+		},
 
 		// XXX: Remove this once templates will be available
 		Resources: corev1.ResourceRequirements{
@@ -572,7 +575,12 @@ func (p *applier) genPSMDBBackupSpec() (psmdbv1.BackupSpec, error) {
 			},
 		},
 	}
-
+	// We preserve the settings for existing DBs, otherwise restarts are seen when upgrading Everest.
+	// TODO: Remove this once we figure out how to apply such spec changes without automatic restarts.
+	// See: https://perconadev.atlassian.net/browse/EVEREST-1413
+	if p.DB.Status.Status == everestv1alpha1.AppStateReady {
+		psmdbBackupSpec.Configuration = p.currentPSMDBSpec.Backup.Configuration
+	}
 	storages := make(map[string]psmdbv1.BackupStorageSpec)
 
 	// List DatabaseClusterBackup objects for this database

--- a/controllers/providers/psmdb/applier.go
+++ b/controllers/providers/psmdb/applier.go
@@ -39,7 +39,8 @@ const (
       operationProfiling:
         mode: slowOp
 `
-	encryptionKeySuffix = "-mongodb-encryption-key"
+	encryptionKeySuffix          = "-mongodb-encryption-key"
+	defaultBackupStartingTimeout = 120
 )
 
 type applier struct {
@@ -565,7 +566,7 @@ func (p *applier) genPSMDBBackupSpec() (psmdbv1.BackupSpec, error) {
 		},
 		Configuration: psmdbv1.BackupConfig{
 			BackupOptions: &psmdbv1.BackupOptions{
-				Timeouts: &psmdbv1.BackupTimeouts{Starting: pointer.ToUint32(120)},
+				Timeouts: &psmdbv1.BackupTimeouts{Starting: pointer.ToUint32(defaultBackupStartingTimeout)},
 			},
 		},
 

--- a/e2e-tests/tests/features/dbbackup_psmdb/10-assert.yaml
+++ b/e2e-tests/tests/features/dbbackup_psmdb/10-assert.yaml
@@ -32,6 +32,12 @@ kind: PerconaServerMongoDB
 metadata:
   name: test-psmdb-cluster
 spec:
+  backup:
+    configuration:
+      backupOptions:
+        oplogSpanMin: 0
+        timeouts:
+          startingStatus: 120
   multiCluster:
     enabled: false
 status:


### PR DESCRIPTION
**Update default PBM startingStatus for new clusters**
---
**Problem:**
EVEREST-1598

The error `couldn''t get response from all shards: convergeClusterWithTimeout: 33s:` can appear for sharded clusters (see EVEREST-1594). There is no certainty why exactly it appears, but the more shards the cluster has the bigger is the chance to face that limit. 
As discussed with experts, it would make sense to increase the default timeout. There's no strict recommendations which new default value to use, so it was decided to use 120s as there were a couple of cases when it helped in the past. 


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
