### PR TITLE
EVEREST-1330 Allow editing of the sharding parameters

### DIFF
--- a/controllers/providers/psmdb/applier.go
+++ b/controllers/providers/psmdb/applier.go
@@ -111,10 +111,8 @@ func (p *applier) configureSharding() {
 		p.configureReplSetSpec(psmdb.Spec.Replsets[i], rsName(i))
 	}
 
-	if psmdb.Spec.Sharding.ConfigsvrReplSet == nil {
-		psmdb.Spec.Sharding.ConfigsvrReplSet = &psmdbv1.ReplsetSpec{}
-		p.configureConfigsvrReplSet(psmdb.Spec.Sharding.ConfigsvrReplSet)
-	}
+	psmdb.Spec.Sharding.ConfigsvrReplSet = &psmdbv1.ReplsetSpec{}
+	p.configureConfigsvrReplSet(psmdb.Spec.Sharding.ConfigsvrReplSet)
 }
 
 func rsName(i int) string {
@@ -205,13 +203,6 @@ func (p *applier) Proxy() error {
 		MultiAZ: psmdbv1.MultiAZ{
 			Affinity: &psmdbv1.PodAffinity{
 				Advanced: common.DefaultAffinitySettings().DeepCopy(),
-			},
-			Resources: corev1.ResourceRequirements{
-				// XXX: Remove this once templates will be available
-				Limits: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("128Mi"),
-					corev1.ResourceCPU:    resource.MustParse("200m"),
-				},
 			},
 		},
 	}

--- a/controllers/providers/psmdb/applier.go
+++ b/controllers/providers/psmdb/applier.go
@@ -206,6 +206,7 @@ func (p *applier) Proxy() error {
 			},
 		},
 	}
+
 	if !database.Spec.Proxy.Resources.CPU.IsZero() {
 		psmdb.Spec.Sharding.Mongos.Resources.Limits[corev1.ResourceCPU] = database.Spec.Proxy.Resources.CPU
 	}


### PR DESCRIPTION
**Allow editing of the sharding parameters**
---
**Problem:**
EVEREST-1330

Editing of the sharding parameters wasn't allowed, since at some point we decided to release only the _enabling for new clusters_ functionality. Since then at some point it was decided to release the editing as well, however the implementation for editing was not implemented. 

Note: scaling down the number of shards still does not take any effect, bc it's not clear how it should work, how it will affect the data, if there are any additional preparation steps needed to perform and finally - if it's even a valid use case. Figuring it out with experts. 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
