### PR TITLE
EVEREST-107 Remove trivy

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -88,14 +88,3 @@ jobs:
           push: true
           tags: ${{ steps.bundle_meta.outputs.tags }}
           file: bundle.Dockerfile
-  scan:
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.12.0
-        with:
-          image-ref: 'docker.io/percona/everest-operator:latest'
-          format: 'table'
-          exit-code: '1'
-          severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-107

At some point trivy started to fail the pipelines from time to time bc of the `TOOMANYREQUESTS` error. There are several workarounds but none of them 100% guarantee. 
Since we have Snyk which also scans for vulnerabilities, I don't think it's worth to go through all the "try and fail" path with workarounds, let's solve it ultimately - remove trivy scans from the Everest pipelines. 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
