### PR TITLE
EVEREST-1700: create secret if it does not exist

### DIFF
--- a/controllers/providers/pxc/applier.go
+++ b/controllers/providers/pxc/applier.go
@@ -24,7 +24,6 @@ import (
 	"github.com/AlekSi/pointer"
 	pxcv1 "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -480,14 +479,10 @@ func (p *applier) applyPMMCfg(monitoring *everestv1alpha1.MonitoringConfig) erro
 		return err
 	}
 
-	err = common.UpdateSecretData(p.ctx, p.C, p.DB, pxc.Spec.SecretsName, map[string][]byte{
+	err = common.CreateOrUpdateSecretData(p.ctx, p.C, p.DB, pxc.Spec.SecretsName, map[string][]byte{
 		"pmmserverkey": []byte(apiKey),
 	})
-	// If the secret does not exist, we need to wait for the PXC
-	// operator to create it. If the secret already exists when the
-	// cluster is initialized the PXC operator doesn't generate the
-	// missing fields.
-	if err != nil && !k8serrors.IsNotFound(err) {
+	if err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1700

*Short explanation of the problem.*
- PXC did not fill in missing fields for a PMM secret before if it was already created. Now it does.

**Solution:**
- Create the secret if it does not exist

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
