### PR TITLE
EVEREST-107 fix builds

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -30,7 +30,7 @@ jobs:
           export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
           export OS=$(uname | awk '{print tolower($0)}')
 
-          export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.25.2
+          export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.38.0
           curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
 
           gpg --keyserver keyserver.ubuntu.com --recv-keys 052996E2A20B5C7E


### PR DESCRIPTION
After merging #597 the builds started failing. Example: https://github.com/percona/everest-operator/actions/runs/12138839528/job/33845128550
This is because we forgot to update the operator-sdk version in the build pipeline