### PR TITLE
Revert https://github.com/percona/everest-operator/pull/596

### DIFF
--- a/internal/controller/providers/pxc/applier.go
+++ b/internal/controller/providers/pxc/applier.go
@@ -24,6 +24,7 @@ import (
 	"github.com/AlekSi/pointer"
 	pxcv1 "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -500,10 +501,10 @@ func (p *applier) applyPMMCfg(monitoring *everestv1alpha1.MonitoringConfig) erro
 		return err
 	}
 
-	err = common.CreateOrUpdateSecretData(p.ctx, p.C, p.DB, pxc.Spec.SecretsName, map[string][]byte{
+	err = common.UpdateSecretData(p.ctx, p.C, p.DB, pxc.Spec.SecretsName, map[string][]byte{
 		"pmmserverkey": []byte(apiKey),
 	})
-	if err != nil {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	}
 	return nil


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1700

Revert https://github.com/percona/everest-operator/pull/596

The internal secrets are not reconciled by the PXC operator correctly, and as a result, the PXC pods are sometimes stuck in `ContainerCreateConfigErr` state.

This reversal is a temporary workaround until an upstream fix is available.

**Cause:**

The PXC operator does not watch the Secret provided in `.spec.secretsName`. If this Secret is initially created by the the user (or everest-operator), then the PXC controller caches this version first, and then updates it with the new values. However, since the controller does not watch this secret, the cache is not updated. When the `internal-` secret is created the first time, it is looking at this outdated secret from the cache, and as a result, the pods get stuck.

Once the pods get stuck, the controller never reconciles the internal secret.

**Solution:**

Revert this PR so that the PXC operator creates this secret by itself. If it does, then when creating the `internal` secret, the `Get` call to the secret is a cache-miss, and it fetches the new state of the secret.

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
