### PR TITLE
EVEREST-1818 | fix DBEngine status reconciliation

### DIFF
--- a/internal/controller/databaseengine_controller.go
+++ b/internal/controller/databaseengine_controller.go
@@ -127,6 +127,7 @@ func (r *DatabaseEngineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// Not ready yet, update status and check again later.
+	dbEngine.Status.OperatorVersion = version // even though deployment is not ready, we still know the version through the image tag.
 	if !ready {
 		dbEngine.Status.State = everestv1alpha1.DBEngineStateInstalling
 		if err := r.reconcileOperatorUpgradeStatus(ctx, dbEngine); err != nil {
@@ -136,7 +137,6 @@ func (r *DatabaseEngineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			r.Status().Update(ctx, dbEngine)
 	}
 
-	dbEngine.Status.OperatorVersion = version
 	timeUntilUnlock, err := r.tryUnlockDBEngine(ctx, dbEngine)
 	if err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1818

DBEngine reconciler complains CSV NotFound when reconciling the status.

**Cause:**

DBEngine reconciler tries to get the CSV based on the `.status.OperatorVersion` of the given DBEngine. However, this field is set only after the DB operator deployment is ready. Until then it keeps reporting these not found errors.

**Solution:**
Set the `.status.OperatorVersion` field even if the deployment is not ready.

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
