### PR TITLE
EVEREST-1820 | fix DBR controller watcher

### DIFF
--- a/internal/controller/databasecluster_controller.go
+++ b/internal/controller/databasecluster_controller.go
@@ -863,7 +863,7 @@ func (r *DatabaseClusterReconciler) ReconcileWatchers(ctx context.Context) error
 	log := log.FromContext(ctx)
 	addWatcher := func(dbEngineType everestv1alpha1.EngineType, obj client.Object) error {
 		sources := []source.Source{
-			source.TypedKind(r.Cache, obj, &handler.EnqueueRequestForObject{}),
+			source.Kind(r.Cache, obj, &handler.EnqueueRequestForObject{}),
 		}
 
 		// special case for PXC - we need to watch pxc-restore to be sure the db is reconciled on every pxc-restore status update.

--- a/internal/controller/databaseclusterrestore_controller.go
+++ b/internal/controller/databaseclusterrestore_controller.go
@@ -668,7 +668,18 @@ func (r *DatabaseClusterRestoreReconciler) ReconcileWatchers(ctx context.Context
 
 	log := log.FromContext(ctx)
 	addWatcher := func(dbEngineType everestv1alpha1.EngineType, obj client.Object) error {
-		src := source.TypedKind(r.Cache, obj, handler.EnqueueRequestForOwner(r.Scheme, r.RESTMapper(), &everestv1alpha1.DatabaseCluster{}))
+		// This source is the same as calling Owns() on the controller builder.
+		// I.e, &DatabaseClusterRestore{} owns obj.
+		src := source.Kind(
+			r.Cache,
+			obj,
+			handler.EnqueueRequestForOwner(
+				r.Scheme,
+				r.RESTMapper(),
+				&everestv1alpha1.DatabaseClusterRestore{},
+				handler.OnlyControllerOwner(),
+			),
+		)
 		if err := r.controller.addWatchers(string(dbEngineType), src); err != nil {
 			return err
 		}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1820

The DBR controller is missing events from the upstream restore objects.

**Cause:**

Wrong owner type provided in the watch (`&DatabaseCluster{}`).

**Solution:**

Provide the correct owner type `&DatabaseClusterRestore{}`. Also add an extra option to enqueue only controlling owner (to align it exactly with `Owns()`)

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
