### PR TITLE
EVEREST-1814 add creating state

### DIFF
--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -33,6 +33,8 @@ var (
 const (
 	// AppStateUnknown is an unknown state.
 	AppStateUnknown AppState = "unknown"
+	// AppStateCreating is used when the db did not start to initialize yet.
+	AppStateCreating AppState = "creating"
 	// AppStateInit is a initializing state.
 	AppStateInit AppState = "initializing"
 	// AppStatePaused is a paused state.
@@ -100,6 +102,18 @@ const (
 	// EngineSizeLarge represents a large engine size.
 	EngineSizeLarge EngineSize = "large"
 )
+
+// WithCreatingState transforms empty and unknown states to a single AppStateCreating.
+// The upstream operators have the different statuses when a cluster is being created -
+// pxc - "unknown", psmdb - "", pg does not have any empty status.
+// Everest maps the DB status 1:1, and there is no point so far to create a separate mapping
+// for each upstream operator separately only because we want to unify AppStateCreating.
+func (s AppState) WithCreatingState() AppState {
+	if s == AppStateUnknown || s == AppStateNew {
+		return AppStateCreating
+	}
+	return s
+}
 
 // Applier provides methods for specifying how to apply a DatabaseCluster CR
 // onto the CR(s) provided by the underlying DB operators (e.g. PerconaXtraDBCluster, PerconaServerMongoDB, PerconaPGCluster, etc.)

--- a/internal/controller/providers/pg/provider.go
+++ b/internal/controller/providers/pg/provider.go
@@ -94,7 +94,7 @@ func (p *Provider) Status(ctx context.Context) (everestv1alpha1.DatabaseClusterS
 	pg := p.PerconaPGCluster
 
 	status := p.DB.Status
-	status.Status = everestv1alpha1.AppState(pg.Status.State)
+	status.Status = everestv1alpha1.AppState(pg.Status.State).WithCreatingState()
 	status.Hostname = pg.Status.Host
 	status.Ready = pg.Status.Postgres.Ready + pg.Status.PGBouncer.Ready
 	status.Size = pg.Status.Postgres.Size + pg.Status.PGBouncer.Size

--- a/internal/controller/providers/psmdb/provider.go
+++ b/internal/controller/providers/psmdb/provider.go
@@ -117,7 +117,7 @@ func (p *Provider) Status(ctx context.Context) (everestv1alpha1.DatabaseClusterS
 	psmdb := p.PerconaServerMongoDB
 
 	activeStorage := getActiveStorage(psmdb)
-	status.Status = everestv1alpha1.AppState(psmdb.Status.State)
+	status.Status = everestv1alpha1.AppState(psmdb.Status.State).WithCreatingState()
 	status.Hostname = psmdb.Status.Host
 	status.Ready = psmdb.Status.Ready
 	status.Size = psmdb.Status.Size

--- a/internal/controller/providers/pxc/provider.go
+++ b/internal/controller/providers/pxc/provider.go
@@ -199,7 +199,7 @@ func (p *Provider) Status(ctx context.Context) (everestv1alpha1.DatabaseClusterS
 	status := p.DB.Status
 	pxc := p.PerconaXtraDBCluster
 
-	status.Status = everestv1alpha1.AppState(p.PerconaXtraDBCluster.Status.Status)
+	status.Status = everestv1alpha1.AppState(p.PerconaXtraDBCluster.Status.Status).WithCreatingState()
 	status.Hostname = pxc.Status.Host
 	status.Ready = pxc.Status.Ready
 	status.Size = pxc.Status.Size


### PR DESCRIPTION
**Add "Creating" DB status**
---
**Problem:**
EVEREST-1814

**Problem:**
The DB can be in an ‘unknown’ state for a couple of seconds and we didn't want to show that to the user. 

**Solution:**

The upstream operators have the different statuses when a cluster is being created: 
- pxc - "unknown"
- psmdb - ""
- pg does not have any empty status.

So the upstream statuses are different although Everest maps the DB status to the upstream cluster status 1:1. There is no point so far to create a separate mapping for each upstream operator only because we want to unify AppStateCreating, so in this PR the Everest operator unifies the "" and "unknown" statuses into the "creating" status. 

**Related PRs:** 
- https://github.com/percona/everest/pull/1084

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
