### PR TITLE
EVEREST-1628 Do not use db.spec.backup.enabled

### DIFF
--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -284,7 +284,7 @@ type BackupSchedule struct {
 // Backup is the backup configuration.
 type Backup struct {
 	// Enabled is a flag to enable backups
-	// Deprecated
+	// Deprecated. Please use db.spec.backup.pitr.enabled and db.spec.backup.schedules[].enabled instead
 	Enabled bool `json:"enabled"`
 	// Schedules is a list of backup schedules
 	Schedules []BackupSchedule `json:"schedules,omitempty"`

--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -284,7 +284,7 @@ type BackupSchedule struct {
 // Backup is the backup configuration.
 type Backup struct {
 	// Enabled is a flag to enable backups
-	// Deprecated. Please db.spec.backup.schedules[].enabled to control each schedule separately and db.spec.backup.pitr.enabled to control PITR.
+	// Deprecated. Please use db.spec.backup.schedules[].enabled to control each schedule separately and db.spec.backup.pitr.enabled to control PITR.
 	Enabled bool `json:"enabled"`
 	// Schedules is a list of backup schedules
 	Schedules []BackupSchedule `json:"schedules,omitempty"`

--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -284,7 +284,7 @@ type BackupSchedule struct {
 // Backup is the backup configuration.
 type Backup struct {
 	// Enabled is a flag to enable backups
-	// Deprecated. Please use db.spec.backup.pitr.enabled and db.spec.backup.schedules[].enabled instead
+	// Deprecated. Please db.spec.backup.schedules[].enabled to control each schedule separately and db.spec.backup.pitr.enabled to control PITR.
 	Enabled bool `json:"enabled"`
 	// Schedules is a list of backup schedules
 	Schedules []BackupSchedule `json:"schedules,omitempty"`

--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -284,6 +284,7 @@ type BackupSchedule struct {
 // Backup is the backup configuration.
 type Backup struct {
 	// Enabled is a flag to enable backups
+	// Deprecated
 	Enabled bool `json:"enabled"`
 	// Schedules is a list of backup schedules
 	Schedules []BackupSchedule `json:"schedules,omitempty"`

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -78,7 +78,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-02-06T08:29:15Z"
+    createdAt: "2025-02-06T08:39:15Z"
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: everest-operator.v0.0.0

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -78,7 +78,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-01-21T11:40:01Z"
+    createdAt: "2025-02-06T08:29:15Z"
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: everest-operator.v0.0.0

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -78,7 +78,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-02-06T08:39:15Z"
+    createdAt: "2025-02-06T11:37:23Z"
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: everest-operator.v0.0.0

--- a/bundle/manifests/everest.percona.com_databaseclusters.yaml
+++ b/bundle/manifests/everest.percona.com_databaseclusters.yaml
@@ -69,7 +69,9 @@ spec:
                 description: Backup is the backup specification
                 properties:
                   enabled:
-                    description: Enabled is a flag to enable backups
+                    description: |-
+                      Enabled is a flag to enable backups
+                      Deprecated
                     type: boolean
                   pitr:
                     description: PITR is the configuration of the point in time recovery

--- a/bundle/manifests/everest.percona.com_databaseclusters.yaml
+++ b/bundle/manifests/everest.percona.com_databaseclusters.yaml
@@ -71,7 +71,7 @@ spec:
                   enabled:
                     description: |-
                       Enabled is a flag to enable backups
-                      Deprecated
+                      Deprecated. Please use db.spec.backup.pitr.enabled and db.spec.backup.schedules[].enabled instead
                     type: boolean
                   pitr:
                     description: PITR is the configuration of the point in time recovery

--- a/bundle/manifests/everest.percona.com_databaseclusters.yaml
+++ b/bundle/manifests/everest.percona.com_databaseclusters.yaml
@@ -71,7 +71,7 @@ spec:
                   enabled:
                     description: |-
                       Enabled is a flag to enable backups
-                      Deprecated. Please use db.spec.backup.pitr.enabled and db.spec.backup.schedules[].enabled instead
+                      Deprecated. Please db.spec.backup.schedules[].enabled to control each schedule separately and db.spec.backup.pitr.enabled to control PITR.
                     type: boolean
                   pitr:
                     description: PITR is the configuration of the point in time recovery

--- a/config/crd/bases/everest.percona.com_databaseclusters.yaml
+++ b/config/crd/bases/everest.percona.com_databaseclusters.yaml
@@ -69,7 +69,9 @@ spec:
                 description: Backup is the backup specification
                 properties:
                   enabled:
-                    description: Enabled is a flag to enable backups
+                    description: |-
+                      Enabled is a flag to enable backups
+                      Deprecated
                     type: boolean
                   pitr:
                     description: PITR is the configuration of the point in time recovery

--- a/config/crd/bases/everest.percona.com_databaseclusters.yaml
+++ b/config/crd/bases/everest.percona.com_databaseclusters.yaml
@@ -71,7 +71,7 @@ spec:
                   enabled:
                     description: |-
                       Enabled is a flag to enable backups
-                      Deprecated
+                      Deprecated. Please use db.spec.backup.pitr.enabled and db.spec.backup.schedules[].enabled instead
                     type: boolean
                   pitr:
                     description: PITR is the configuration of the point in time recovery

--- a/config/crd/bases/everest.percona.com_databaseclusters.yaml
+++ b/config/crd/bases/everest.percona.com_databaseclusters.yaml
@@ -71,7 +71,7 @@ spec:
                   enabled:
                     description: |-
                       Enabled is a flag to enable backups
-                      Deprecated. Please use db.spec.backup.pitr.enabled and db.spec.backup.schedules[].enabled instead
+                      Deprecated. Please db.spec.backup.schedules[].enabled to control each schedule separately and db.spec.backup.pitr.enabled to control PITR.
                     type: boolean
                   pitr:
                     description: PITR is the configuration of the point in time recovery

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -421,7 +421,9 @@ spec:
                 description: Backup is the backup specification
                 properties:
                   enabled:
-                    description: Enabled is a flag to enable backups
+                    description: |-
+                      Enabled is a flag to enable backups
+                      Deprecated
                     type: boolean
                   pitr:
                     description: PITR is the configuration of the point in time recovery

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -423,7 +423,7 @@ spec:
                   enabled:
                     description: |-
                       Enabled is a flag to enable backups
-                      Deprecated. Please use db.spec.backup.pitr.enabled and db.spec.backup.schedules[].enabled instead
+                      Deprecated. Please db.spec.backup.schedules[].enabled to control each schedule separately and db.spec.backup.pitr.enabled to control PITR.
                     type: boolean
                   pitr:
                     description: PITR is the configuration of the point in time recovery

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -423,7 +423,7 @@ spec:
                   enabled:
                     description: |-
                       Enabled is a flag to enable backups
-                      Deprecated
+                      Deprecated. Please use db.spec.backup.pitr.enabled and db.spec.backup.schedules[].enabled instead
                     type: boolean
                   pitr:
                     description: PITR is the configuration of the point in time recovery

--- a/internal/controller/databasecluster_controller.go
+++ b/internal/controller/databasecluster_controller.go
@@ -472,7 +472,7 @@ func (r *DatabaseClusterReconciler) initIndexers(ctx context.Context, mgr ctrl.M
 		func(o client.Object) []string {
 			var res []string
 			database, ok := o.(*everestv1alpha1.DatabaseCluster)
-			if !ok || !database.Spec.Backup.Enabled {
+			if !ok {
 				return res
 			}
 			for _, storage := range database.Spec.Backup.Schedules {

--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -950,11 +950,8 @@ func (p *applier) reconcilePGBackupsSpec() (pgv2.Backups, error) {
 		return pgv2.Backups{}, err
 	}
 
-	// Only use the backup schedules if schedules are enabled in the DBC spec
-	backupSchedules := []everestv1alpha1.BackupSchedule{}
-	if database.Spec.Backup.Enabled {
-		backupSchedules = database.Spec.Backup.Schedules
-	}
+	backupSchedules := database.Spec.Backup.Schedules
+
 	// Add backup storages used by backup schedules to the list
 	if err := p.addBackupStoragesBySchedules(backupSchedules, backupStorages, backupStoragesSecrets); err != nil {
 		return pgv2.Backups{}, err

--- a/internal/controller/providers/psmdb/applier.go
+++ b/internal/controller/providers/psmdb/applier.go
@@ -654,9 +654,9 @@ func (p *applier) genPSMDBBackupSpec() (psmdbv1.BackupSpec, error) {
 		return emptySpec, err
 	}
 
-	// If scheduled backups are disabled, just return the storages used in
+	// If there are no schedules, just return the storages used in
 	// DatabaseClusterBackup objects
-	if !database.Spec.Backup.Enabled {
+	if len(database.Spec.Backup.Schedules) == 0 {
 		if len(storages) > 1 {
 			return emptySpec, common.ErrPSMDBOneStorageRestriction
 		}

--- a/internal/controller/providers/pxc/applier.go
+++ b/internal/controller/providers/pxc/applier.go
@@ -592,8 +592,8 @@ func (p *applier) genPXCBackupSpec() (*pxcv1.PXCScheduledBackup, error) {
 		}
 	}
 
-	// If scheduled backups are disabled, just return the storages used in DatabaseClusterBackup objects
-	if !database.Spec.Backup.Enabled {
+	// If there are no schedules, just return the storages used in DatabaseClusterBackup objects
+	if len(database.Spec.Backup.Schedules) == 0 {
 		pxcBackupSpec.Storages = storages
 		return pxcBackupSpec, nil
 	}


### PR DESCRIPTION
**Do not use db.spec.backup.enabled**
---
**Problem:**
EVEREST-1628

The field `db.spec.backup.enabled` is confusing, Everest basically doesn't have such a feature as disabling backups, the field was using instead of checking the number of schedules. 

**Solution:**
Instead of using `db.spec.backup.enabled` Everest looks at the number of schedules which keeps the logic.   

**Related pull requests**

- https://github.com/percona/everest/pull/1087

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
