### PR TITLE
EVEREST-1849 | Do not set owner reference on PSMDB user secret

### DIFF
--- a/internal/controller/common/helper.go
+++ b/internal/controller/common/helper.go
@@ -262,6 +262,7 @@ func CreateOrUpdateSecretData(
 	database *everestv1alpha1.DatabaseCluster,
 	secretName string,
 	data map[string][]byte,
+	setControllerRef bool,
 ) error {
 	err := UpdateSecretData(ctx, c, database, secretName, data)
 	if err == nil {
@@ -280,10 +281,14 @@ func CreateOrUpdateSecretData(
 		Type: corev1.SecretTypeOpaque,
 		Data: data,
 	}
-	err = controllerutil.SetControllerReference(database, secret, c.Scheme())
-	if err != nil {
-		return err
+
+	if setControllerRef {
+		err = controllerutil.SetControllerReference(database, secret, c.Scheme())
+		if err != nil {
+			return err
+		}
 	}
+
 	// If the secret does not exist, create it
 	return c.Create(ctx, secret)
 }

--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -309,10 +309,16 @@ func (p *applier) applyPMMCfg(monitoring *everestv1alpha1.MonitoringConfig) erro
 		return err
 	}
 
+	// We avoid setting the controller reference for the Secret here.
+	// The PSMDB operator handles Secret cleanup automatically as part of the `delete-psmdb-pvc` finalizer process.
+	// If we were to set the controller reference, the Secret would be deleted before the PSMDB cluster, leading to
+	// the PSMDB operator recreating the Secret and restarting the DB pods to sync updated user information,
+	// which would cause unnecessary restarts.
 	if err := common.CreateOrUpdateSecretData(ctx, c, database, pg.Spec.PMM.Secret,
 		map[string][]byte{
 			"PMM_SERVER_KEY": []byte(apiKey),
 		},
+		true,
 	); err != nil {
 		return err
 	}

--- a/internal/controller/providers/psmdb/applier.go
+++ b/internal/controller/providers/psmdb/applier.go
@@ -370,6 +370,7 @@ func (p *applier) applyPMMCfg(monitoring *everestv1alpha1.MonitoringConfig) erro
 		map[string][]byte{
 			"PMM_SERVER_API_KEY": []byte(apiKey),
 		},
+		false,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1849

Fixes the issue with PSMDB clusters restarting upon deletion.

**Cause:**
- we set an owner reference on the user secret created by the everest-operator
- upon deletion of the cluster, this user secret is automatically deleted first due to the owner reference
- once the secret is deleted, the psmdb-operator recreates with new default information
- since the secret was technically changed, the psmdb-operator needs to restart the statefulset pods in order to propagate the new information, leading to restarts

**Solution:**
Do not set the owner reference on the secret. The psmdb-operator shall anyway handle the secret clean-up as a part of the `delete-psmdb-pvc` finalizer. This way, the secret is deleted by the psmdb-operator only after the pods are deleted, hence avoiding any unnecessary restarts.

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
