### PR TITLE
EVEREST-1883 update ubuntu images

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check:
     name: Checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Update ubuntu images**
---
**Problem:**
EVEREST-1883

The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025 == no workflow execution if there is runs-on: ubuntu-20.04

Everest operator doesn't use `ubuntu-20.04` however for the sake of alignment with other repos, let's use `ubuntu-latest` and do not return to the problem anymore

**Related pull requests**

- https://github.com/percona/everest/pull/1236
- https://github.com/percona/everest-catalog/pull/57
