### PR TITLE
EVEREST-1625 Update dbc API

### DIFF
--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -299,7 +299,7 @@ type BackupSchedule struct {
 type Backup struct {
 	// Enabled is a flag to enable backups
 	// Deprecated. Please use db.spec.backup.schedules[].enabled to control each schedule separately and db.spec.backup.pitr.enabled to control PITR.
-	Enabled bool `json:"enabled"`
+	Enabled bool `json:"enabled,omitempty"`
 	// Schedules is a list of backup schedules
 	Schedules []BackupSchedule `json:"schedules,omitempty"`
 	// PITR is the configuration of the point in time recovery

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -78,7 +78,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-02-14T15:05:36Z"
+    createdAt: "2025-03-25T11:14:30Z"
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: everest-operator.v0.0.0

--- a/bundle/manifests/everest.percona.com_databaseclusters.yaml
+++ b/bundle/manifests/everest.percona.com_databaseclusters.yaml
@@ -123,8 +123,6 @@ spec:
                       - schedule
                       type: object
                     type: array
-                required:
-                - enabled
                 type: object
               dataSource:
                 description: DataSource defines a data source for bootstraping a new

--- a/config/crd/bases/everest.percona.com_databaseclusters.yaml
+++ b/config/crd/bases/everest.percona.com_databaseclusters.yaml
@@ -123,8 +123,6 @@ spec:
                       - schedule
                       type: object
                     type: array
-                required:
-                - enabled
                 type: object
               dataSource:
                 description: DataSource defines a data source for bootstraping a new

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -473,8 +473,6 @@ spec:
                       - schedule
                       type: object
                     type: array
-                required:
-                - enabled
                 type: object
               dataSource:
                 description: DataSource defines a data source for bootstraping a new cluster


### PR DESCRIPTION
**Align DatabaseCluster API**
---
**Problem:**
EVEREST-1625

The `.backup.enabled` field was required previously but not anymore, however it wasn't marked as optional in the CRD, this PR fixes it 

**Related pull requests**
- [link]

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
