### PR TITLE
EVEREST-2011 | Fix issue with DB status not getting reconciled

### DIFF
--- a/internal/controller/databasecluster_controller.go
+++ b/internal/controller/databasecluster_controller.go
@@ -232,8 +232,6 @@ func (r *DatabaseClusterReconciler) reconcileDB(
 	}); err != nil {
 		return ctrl.Result{}, err
 	}
-
-	// Reconcile the status of the DatabaseCluster object.
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/databasecluster_controller.go
+++ b/internal/controller/databasecluster_controller.go
@@ -144,7 +144,7 @@ func (r *DatabaseClusterReconciler) reconcileDB(
 	ctx context.Context,
 	db *everestv1alpha1.DatabaseCluster,
 	p dbProvider,
-) (ctrl.Result, error) {
+) (rr ctrl.Result, rerr error) {
 	// Handle any necessary cleanup.
 	if !db.GetDeletionTimestamp().IsZero() {
 		done, err := p.Cleanup(ctx, db)
@@ -154,6 +154,24 @@ func (r *DatabaseClusterReconciler) reconcileDB(
 		db.Status.Status = everestv1alpha1.AppStateDeleting
 		return ctrl.Result{Requeue: !done}, r.Status().Update(ctx, db)
 	}
+
+	// Update the status of the DatabaseCluster object after the reconciliation.
+	defer func() {
+		status, err := p.Status(ctx)
+		if err != nil {
+			rr = ctrl.Result{}
+			rerr = errors.Join(err, fmt.Errorf("failed to get status"))
+		}
+		db.Status = status
+		db.Status.ObservedGeneration = db.GetGeneration()
+		if err := r.Client.Status().Update(ctx, db); err != nil {
+			rr = ctrl.Result{}
+			rerr = errors.Join(err, fmt.Errorf("failed to update status"))
+		}
+		if status.Status != everestv1alpha1.AppStateInit {
+			rr = ctrl.Result{RequeueAfter: defaultRequeueAfter}
+		}
+	}()
 
 	log := log.FromContext(ctx)
 	hr, err := p.RunPreReconcileHook(ctx)
@@ -216,18 +234,6 @@ func (r *DatabaseClusterReconciler) reconcileDB(
 	}
 
 	// Reconcile the status of the DatabaseCluster object.
-	status, err := p.Status(ctx)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	db.Status = status
-	db.Status.ObservedGeneration = db.GetGeneration()
-	if err := r.Client.Status().Update(ctx, db); err != nil {
-		return ctrl.Result{}, err
-	}
-	if status.Status != everestv1alpha1.AppStateInit {
-		return ctrl.Result{RequeueAfter: defaultRequeueAfter}, nil
-	}
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
#### Problem

PXC clusters sometimes do not show `restoring` state when a restore is in-progress

#### Cause

In https://github.com/percona/everest-operator/pull/739 we merged a change where the reconciliation loop does an early exit if there is a restore in-progress. This was done to skip reconciliation in order to avoid interfering with the pxc-operator during the restore. 

As an unintended side-effect, this also resulted in the status updates being skipped. This meant that even though a restore was in progress, the DB status was not updated to show it.

#### Soluton

Ensure that status is always reconciled regardless of the early exit. We do this by moving the status update code up ahead into a defer block.