### PR TITLE
EVEREST-107 | Fix typo in requeue logic

### DIFF
--- a/internal/controller/databasecluster_controller.go
+++ b/internal/controller/databasecluster_controller.go
@@ -169,7 +169,8 @@ func (r *DatabaseClusterReconciler) reconcileDB(
 			rr = ctrl.Result{}
 			rerr = errors.Join(err, fmt.Errorf("failed to update status: %w", err))
 		}
-		if status.Status != everestv1alpha1.AppStateInit {
+		// DB is not ready, check again soon.
+		if status.Status != everestv1alpha1.AppStateReady {
 			rr = ctrl.Result{RequeueAfter: defaultRequeueAfter}
 		}
 	}()


### PR DESCRIPTION
Possible typo introduced from https://github.com/percona/everest-operator/pull/697