### PR TITLE
EVEREST-2054 feat(expose): add support for custom annotations and labels in expose config

### DIFF
--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -207,6 +207,9 @@ type Expose struct {
 	// IPSourceRanges is the list of IP source ranges (CIDR notation)
 	// to allow access from. If not set, there is no limitations
 	IPSourceRanges []IPSourceRange `json:"ipSourceRanges,omitempty"`
+
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 }
 
 func (e *Expose) toCIDR(ranges []IPSourceRange) []IPSourceRange {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -739,6 +739,20 @@ func (in *Expose) DeepCopyInto(out *Expose) {
 		in, out := &in.IPSourceRanges, &out.IPSourceRanges
 		*out = make([]IPSourceRange, len(*in))
 		copy(*out, *in)
+	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 }
 

--- a/config/crd/bases/everest.percona.com_databaseclusters.yaml
+++ b/config/crd/bases/everest.percona.com_databaseclusters.yaml
@@ -321,6 +321,10 @@ spec:
                   expose:
                     description: Expose is the proxy expose configuration
                     properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
                       ipSourceRanges:
                         description: |-
                           IPSourceRanges is the list of IP source ranges (CIDR notation)
@@ -330,6 +334,10 @@ spec:
                             notation or without a netmask.
                           type: string
                         type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       type:
                         default: internal
                         description: Type is the expose type, can be internal or external

--- a/internal/controller/common/consts.go
+++ b/internal/controller/common/consts.go
@@ -78,12 +78,21 @@ const (
 	ForegroundDeletionFinalizer = "foregroundDeletion"
 )
 
-// ExposeAnnotationsMap is a map of annotations needed for exposing the database cluster.
-var ExposeAnnotationsMap = map[ClusterType]map[string]string{
+// ExposeExternalAnnotationsMap is a map of annotations needed for exposing the database cluster externally.
+var ExposeExternalAnnotationsMap = map[ClusterType]map[string]string{
 	ClusterTypeEKS: {
 		"service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
 	},
 }
+
+// ExposeInternalAnnotationsMap is a map of annotations needed for exposing the database cluster internally.
+var ExposeInternalAnnotationsMap = map[ClusterType]map[string]string{}
+
+// ExposeExternalLabelsMap is a map of labels needed for exposing the database cluster externally.
+var ExposeExternalLabelsMap = map[ClusterType]map[string]string{}
+
+// ExposeInternalLabelsMap is a map of labels needed for exposing the database cluster internally.
+var ExposeInternalLabelsMap = map[ClusterType]map[string]string{}
 
 //noling:gochecknoglobals
 var (

--- a/internal/controller/common/helper.go
+++ b/internal/controller/common/helper.go
@@ -144,6 +144,26 @@ func GetClusterType(ctx context.Context, c client.Client) (ClusterType, error) {
 	return clusterType, nil
 }
 
+func MergeAnnotations(annotationMaps ...map[string]string) map[string]string {
+	result := make(map[string]string)
+
+	for _, annotations := range annotationMaps {
+		if annotations == nil || len(annotations) == 0 {
+			continue
+		}
+
+		for key, value := range annotations {
+			result[key] = value
+		}
+	}
+
+	return result
+}
+
+func MergeLabels(labelMaps ...map[string]string) map[string]string {
+	return MergeAnnotations(labelMaps...)
+}
+
 func mergeMap(dst map[string]interface{}, src map[string]interface{}) error {
 	return mergeMapInternal(dst, src, "")
 }

--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -191,14 +191,27 @@ func (p *applier) Proxy() error {
 		pg.Spec.Proxy.PGBouncer.ServiceExpose = &pgv2.ServiceExpose{
 			Type: string(corev1.ServiceTypeClusterIP),
 		}
+		pg.Spec.Proxy.PGBouncer.ServiceExpose.Metadata.Annotations = common.MergeAnnotations(
+			common.ExposeInternalAnnotationsMap[p.clusterType],
+			database.Spec.Proxy.Expose.Annotations,
+		)
+		pg.Spec.Proxy.PGBouncer.ServiceExpose.Metadata.Labels = common.MergeLabels(
+			common.ExposeInternalLabelsMap[p.clusterType],
+			database.Spec.Proxy.Expose.Labels,
+		)
 	case everestv1alpha1.ExposeTypeExternal:
 		pg.Spec.Proxy.PGBouncer.ServiceExpose = &pgv2.ServiceExpose{
 			Type:                     string(corev1.ServiceTypeLoadBalancer),
 			LoadBalancerSourceRanges: p.DB.Spec.Proxy.Expose.IPSourceRangesStringArray(),
 		}
-		if annotations, ok := common.ExposeAnnotationsMap[p.clusterType]; ok {
-			pg.Spec.Proxy.PGBouncer.ServiceExpose.Metadata.Annotations = annotations
-		}
+		pg.Spec.Proxy.PGBouncer.ServiceExpose.Metadata.Annotations = common.MergeAnnotations(
+			common.ExposeExternalAnnotationsMap[p.clusterType],
+			database.Spec.Proxy.Expose.Annotations,
+		)
+		pg.Spec.Proxy.PGBouncer.ServiceExpose.Metadata.Labels = common.MergeLabels(
+			common.ExposeExternalLabelsMap[p.clusterType],
+			database.Spec.Proxy.Expose.Labels,
+		)
 	default:
 		return fmt.Errorf("invalid expose type %s", database.Spec.Proxy.Expose.Type)
 	}

--- a/internal/controller/providers/psmdb/applier.go
+++ b/internal/controller/providers/psmdb/applier.go
@@ -276,12 +276,26 @@ func (p *applier) exposeShardedCluster(expose *psmdbv1.MongosExpose) error {
 	switch database.Spec.Proxy.Expose.Type {
 	case everestv1alpha1.ExposeTypeInternal:
 		expose.ExposeType = corev1.ServiceTypeClusterIP
+		expose.ServiceAnnotations = common.MergeAnnotations(
+			common.ExposeInternalAnnotationsMap[p.clusterType],
+			database.Spec.Proxy.Expose.Annotations,
+		)
+		expose.ServiceLabels = common.MergeLabels(
+			common.ExposeInternalLabelsMap[p.clusterType],
+			database.Spec.Proxy.Expose.Labels,
+		)
 	case everestv1alpha1.ExposeTypeExternal:
 		expose.ExposeType = corev1.ServiceTypeLoadBalancer
 		expose.LoadBalancerSourceRanges = database.Spec.Proxy.Expose.IPSourceRangesStringArray()
-		if annotations, ok := common.ExposeAnnotationsMap[p.clusterType]; ok {
-			expose.ServiceAnnotations = annotations
-		}
+		expose.ServiceAnnotations = common.MergeAnnotations(
+			common.ExposeExternalAnnotationsMap[p.clusterType],
+			database.Spec.Proxy.Expose.Annotations,
+		)
+		expose.ServiceLabels = common.MergeLabels(
+			common.ExposeExternalLabelsMap[p.clusterType],
+			database.Spec.Proxy.Expose.Labels,
+		)
+
 	default:
 		return fmt.Errorf("invalid expose type %s", database.Spec.Proxy.Expose.Type)
 	}
@@ -294,13 +308,26 @@ func (p *applier) exposeDefaultReplSet(expose *psmdbv1.ExposeTogglable) error {
 	case everestv1alpha1.ExposeTypeInternal:
 		expose.Enabled = false
 		expose.ExposeType = corev1.ServiceTypeClusterIP
+		expose.ServiceAnnotations = common.MergeAnnotations(
+			common.ExposeInternalAnnotationsMap[p.clusterType],
+			database.Spec.Proxy.Expose.Annotations,
+		)
+		expose.ServiceLabels = common.MergeLabels(
+			common.ExposeInternalLabelsMap[p.clusterType],
+			database.Spec.Proxy.Expose.Labels,
+		)
 	case everestv1alpha1.ExposeTypeExternal:
 		expose.Enabled = true
 		expose.ExposeType = corev1.ServiceTypeLoadBalancer
 		expose.LoadBalancerSourceRanges = database.Spec.Proxy.Expose.IPSourceRangesStringArray()
-		if annotations, ok := common.ExposeAnnotationsMap[p.clusterType]; ok {
-			expose.ServiceAnnotations = annotations
-		}
+		expose.ServiceAnnotations = common.MergeAnnotations(
+			common.ExposeExternalAnnotationsMap[p.clusterType],
+			database.Spec.Proxy.Expose.Annotations,
+		)
+		expose.ServiceLabels = common.MergeLabels(
+			common.ExposeExternalLabelsMap[p.clusterType],
+			database.Spec.Proxy.Expose.Labels,
+		)
 	default:
 		return fmt.Errorf("invalid expose type %s", database.Spec.Proxy.Expose.Type)
 	}


### PR DESCRIPTION
This introduces `annotations` and `labels` fields to the `Expose` struct, enabling users to inject custom metadata into exposed services. Both internal and external expose configurations are now merged with predefined annotation/label maps based on cluster type.

Includes:
- CRD updates to reflect new `annotations` and `labels` schema fields.
- DeepCopy generation support for the new fields.
- Consolidation of annotations and labels merging logic.
- Application logic updates across PostgreSQL, PXC, and PSMDB providers.

This improves flexibility and control over service metadata in Kubernetes environments. It adds the most essential capability for production use.
