### PR TITLE
EVEREST-2006 | DataImporter improvements

### DIFF
--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -287,7 +287,7 @@ type DataSource struct {
 	// DataImport allows importing data from an external backup source.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message=".spec.dataSource.dataImport is immutable"
-	DataImport *DataImportJobTemplate `json:"dataImport"`
+	DataImport *DataImportJobTemplate `json:"dataImport,omitempty"`
 }
 
 // BackupSchedule is the backup schedule configuration.

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -78,7 +78,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-06-25T12:20:31Z"
+    createdAt: "2025-06-26T10:51:29Z"
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: everest-operator.v0.0.0

--- a/internal/consts/annotations.go
+++ b/internal/consts/annotations.go
@@ -26,4 +26,8 @@ const (
 	PauseReconcileAnnotationValueTrue = "true"
 	// RestartAnnotation is the annotation used to trigger a restart of a database cluster.
 	RestartAnnotation = EverestAnnotationPrefix + "restart"
+	// ManagedByDataImportAnnotation is the annotation used to indicate that a resource is managed by a data import process.
+	ManagedByDataImportAnnotation = EverestAnnotationPrefix + "managed-by-data-import"
+	// ManagedByDataImportAnnotationValueTrue is the value for the ManagedByDataImportAnnotation to indicate that the resource is managed by data import.
+	ManagedByDataImportAnnotationValueTrue = "true"
 )

--- a/internal/controller/databaseclusterrestore_controller.go
+++ b/internal/controller/databaseclusterrestore_controller.go
@@ -805,6 +805,11 @@ func (r *DatabaseClusterRestoreReconciler) tryCreatePG(ctx context.Context, obj 
 		return err
 	}
 
+	if val, ok := pgRestore.GetAnnotations()[consts.ManagedByDataImportAnnotation]; ok && val == consts.ManagedByDataImportAnnotationValueTrue {
+		// part of data import, do not create a DBR.
+		return nil
+	}
+
 	pg := &pgv2.PerconaPGCluster{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: pgRestore.Spec.PGCluster}, pg); err != nil {
 		// if such upstream cluster is not found - do nothing

--- a/internal/data-importer/deploy/psmdb/dataimporter.yaml
+++ b/internal/data-importer/deploy/psmdb/dataimporter.yaml
@@ -16,6 +16,12 @@ spec:
     - .spec.engine.userSecretsName
   permissions:
   - apiGroups:
+    - everest.percona.com
+    resources:
+    - databaseclusters
+    verbs:
+    - get
+  - apiGroups:
     - ""
     resources:
     - secrets
@@ -32,3 +38,4 @@ spec:
     - get
     - create
     - update
+


### PR DESCRIPTION
### Problem

1. Upstream restore objects created by data importers are orphan and cannot be deleted
2. DBR created for PGRestore created by data importers

### Solution
1. Attach owner ref to DB, so that it is automatically deleted when DB is deleted.
2. Add an annotation to skip creating DBR