### PR TITLE
Revert (#752) EVEREST-1012 PG restore from DataSource

### DIFF
--- a/internal/controller/databaseclusterbackup_controller.go
+++ b/internal/controller/databaseclusterbackup_controller.go
@@ -272,7 +272,7 @@ func (r *DatabaseClusterBackupReconciler) initIndexers(ctx context.Context, mgr 
 	return err
 }
 
-func (r *DatabaseClusterBackupReconciler) watchHandler(creationFunc func(ctx context.Context, obj client.Object) error) handler.Funcs { //nolint:dupl
+func (r *DatabaseClusterBackupReconciler) watchHandler(creationFunc func(ctx context.Context, obj client.Object) error) handler.Funcs {
 	return handler.Funcs{
 		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			r.tryCreateDBBackups(ctx, e.Object, creationFunc)
@@ -867,8 +867,7 @@ func backupStorageName(repoName string, pg *pgv2.PerconaPGCluster, storages *eve
 	for _, repo := range pg.Spec.Backups.PGBackRest.Repos {
 		if repo.Name == repoName {
 			for _, storage := range storages.Items {
-				if repo.S3 != nil &&
-					pg.Namespace == storage.Namespace &&
+				if pg.Namespace == storage.Namespace &&
 					repo.S3.Region == storage.Spec.Region &&
 					repo.S3.Bucket == storage.Spec.Bucket &&
 					repo.S3.Endpoint == storage.Spec.EndpointURL {

--- a/internal/controller/databaseclusterrestore_controller.go
+++ b/internal/controller/databaseclusterrestore_controller.go
@@ -28,16 +28,13 @@ import (
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	pxcv1 "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -220,28 +217,11 @@ func (r *DatabaseClusterRestoreReconciler) ensureClusterIsReady(ctx context.Cont
 
 func (r *DatabaseClusterRestoreReconciler) restorePSMDB(
 	ctx context.Context, restore *everestv1alpha1.DatabaseClusterRestore,
-) (rerr error) {
+) error {
 	logger := log.FromContext(ctx)
 	if err := r.ensureClusterIsReady(ctx, restore); err != nil {
 		return err
 	}
-
-	psmdbCR := &psmdbv1.PerconaServerMongoDBRestore{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      restore.Name,
-			Namespace: restore.Namespace,
-		},
-	}
-	err := r.Get(ctx, types.NamespacedName{Name: restore.Name, Namespace: restore.Namespace}, psmdbCR)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return err
-	}
-	defer func() {
-		rerr = r.updateStatusPSMDB(ctx, restore, psmdbCR)
-		if rerr != nil {
-			logger.Error(rerr, "failed to update status of PXC resource")
-		}
-	}()
 
 	// We need to check if the storage used by the backup is defined in the
 	// PerconaServerMongoDB CR. If not, we requeue the restore to give the
@@ -282,10 +262,16 @@ func (r *DatabaseClusterRestoreReconciler) restorePSMDB(
 		}
 	}
 
+	psmdbCR := &psmdbv1.PerconaServerMongoDBRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      restore.Name,
+			Namespace: restore.Namespace,
+		},
+	}
 	if err := controllerutil.SetControllerReference(restore, psmdbCR, r.Client.Scheme()); err != nil {
 		return err
 	}
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, psmdbCR, func() error {
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, psmdbCR, func() error {
 		psmdbCR.Spec.ClusterName = restore.Spec.DBClusterName
 		if restore.Spec.DataSource.DBClusterBackupName != "" {
 			psmdbCR.Spec.BackupName = restore.Spec.DataSource.DBClusterBackupName
@@ -337,14 +323,16 @@ func (r *DatabaseClusterRestoreReconciler) restorePSMDB(
 
 		return nil
 	})
-	return err
-}
+	if err != nil {
+		return err
+	}
 
-func (r *DatabaseClusterRestoreReconciler) updateStatusPSMDB(
-	ctx context.Context,
-	restore *everestv1alpha1.DatabaseClusterRestore,
-	psmdbCR *psmdbv1.PerconaServerMongoDBRestore,
-) error {
+	psmdbCR = &psmdbv1.PerconaServerMongoDBRestore{}
+	err = r.Get(ctx, types.NamespacedName{Name: restore.Name, Namespace: restore.Namespace}, psmdbCR)
+	if err != nil {
+		return err
+	}
+
 	restore.Status.State = everestv1alpha1.GetDBRestoreState(psmdbCR)
 	restore.Status.CompletedAt = psmdbCR.Status.CompletedAt
 	restore.Status.Message = psmdbCR.Status.Error
@@ -356,29 +344,18 @@ func (r *DatabaseClusterRestoreReconciler) restorePXC(
 	ctx context.Context,
 	restore *everestv1alpha1.DatabaseClusterRestore,
 	db *everestv1alpha1.DatabaseCluster,
-) (rerr error) {
-	logger := log.FromContext(ctx)
+) error {
 	pxcCR := &pxcv1.PerconaXtraDBClusterRestore{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      restore.Name,
 			Namespace: restore.Namespace,
 		},
 	}
-	err := r.Get(ctx, types.NamespacedName{Name: restore.Name, Namespace: restore.Namespace}, pxcCR)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return err
-	}
-	defer func() {
-		rerr = r.updateStatusPXC(ctx, restore, pxcCR)
-		if rerr != nil {
-			logger.Error(rerr, "failed to update status of PXC resource")
-		}
-	}()
 
 	if err := controllerutil.SetControllerReference(restore, pxcCR, r.Client.Scheme()); err != nil {
 		return err
 	}
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, pxcCR, func() error {
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, pxcCR, func() error {
 		pxcCR.Spec.PXCCluster = restore.Spec.DBClusterName
 		if restore.Spec.DataSource.DBClusterBackupName != "" {
 			pxcCR.Spec.BackupName = restore.Spec.DataSource.DBClusterBackupName
@@ -435,42 +412,25 @@ func (r *DatabaseClusterRestoreReconciler) restorePXC(
 		}
 		return nil
 	})
-	return err
-}
+	if err != nil {
+		return err
+	}
 
-func (r *DatabaseClusterRestoreReconciler) updateStatusPXC(
-	ctx context.Context,
-	restore *everestv1alpha1.DatabaseClusterRestore,
-	pxcCR *pxcv1.PerconaXtraDBClusterRestore,
-) error {
+	pxcCR = &pxcv1.PerconaXtraDBClusterRestore{}
+	err = r.Get(ctx, types.NamespacedName{Name: restore.Name, Namespace: restore.Namespace}, pxcCR)
+	if err != nil {
+		return err
+	}
+
 	restore.Status.State = everestv1alpha1.GetDBRestoreState(pxcCR)
 	restore.Status.CompletedAt = pxcCR.Status.CompletedAt
+	restore.Status.Message = pxcCR.Status.Comments
 
 	return r.Status().Update(ctx, restore)
 }
 
-func (r *DatabaseClusterRestoreReconciler) restorePG(ctx context.Context, restore *everestv1alpha1.DatabaseClusterRestore) (rerr error) {
+func (r *DatabaseClusterRestoreReconciler) restorePG(ctx context.Context, restore *everestv1alpha1.DatabaseClusterRestore) error {
 	logger := log.FromContext(ctx)
-	pgCR := &pgv2.PerconaPGRestore{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      restore.Name,
-			Namespace: restore.Namespace,
-		},
-	}
-	err := r.Get(ctx, types.NamespacedName{Name: restore.Name, Namespace: restore.Namespace}, pgCR)
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return err
-	}
-	defer func() {
-		rerr = r.updateStatusPG(ctx, restore, pgCR)
-		if rerr != nil {
-			logger.Error(rerr, "failed to update status of PG resource")
-		}
-	}()
-
-	if restore.IsComplete() {
-		return nil
-	}
 
 	var backupStorageName string
 	var backupBaseName string
@@ -493,7 +453,7 @@ func (r *DatabaseClusterRestoreReconciler) restorePG(ctx context.Context, restor
 	}
 
 	pgDBCR := &pgv2.PerconaPGCluster{}
-	err = r.Get(ctx, types.NamespacedName{Name: restore.Spec.DBClusterName, Namespace: restore.Namespace}, pgDBCR)
+	err := r.Get(ctx, types.NamespacedName{Name: restore.Spec.DBClusterName, Namespace: restore.Namespace}, pgDBCR)
 	if err != nil {
 		logger.Error(err, "unable to fetch PerconaPGCluster")
 		return err
@@ -521,21 +481,28 @@ func (r *DatabaseClusterRestoreReconciler) restorePG(ctx context.Context, restor
 		return ErrBackupStorageUndefined
 	}
 
+	pgCR := &pgv2.PerconaPGRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      restore.Name,
+			Namespace: restore.Namespace,
+		},
+	}
+	if err := controllerutil.SetControllerReference(restore, pgCR, r.Client.Scheme()); err != nil {
+		return err
+	}
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, pgCR, func() error {
-		if err := controllerutil.SetControllerReference(restore, pgCR, r.Client.Scheme()); err != nil {
-			return err
-		}
 		pgCR.Spec.PGCluster = restore.Spec.DBClusterName
 		pgCR.Spec.RepoName = repoName
 		pgCR.Spec.Options, err = getPGRestoreOptions(restore.Spec.DataSource, backupBaseName)
 		return err
 	})
-	return err
-}
+	if err != nil {
+		return err
+	}
 
-func (r *DatabaseClusterRestoreReconciler) updateStatusPG(ctx context.Context, restore *everestv1alpha1.DatabaseClusterRestore, pgCR *pgv2.PerconaPGRestore) error {
 	restore.Status.State = everestv1alpha1.GetDBRestoreState(pgCR)
 	restore.Status.CompletedAt = pgCR.Status.CompletedAt
+
 	return r.Status().Update(ctx, restore)
 }
 
@@ -668,10 +635,6 @@ func (r *DatabaseClusterRestoreReconciler) genPXCPitrRestoreSpec(
 }
 
 func getPGRestoreOptions(dataSource everestv1alpha1.DataSource, backupBaseName string) ([]string, error) {
-	// it happens for bootstraped restores, they only appear with the repoName and clusterName, no details about the particular backup
-	if backupBaseName == "." {
-		return []string{}, nil
-	}
 	options := []string{
 		"--set=" + backupBaseName,
 	}
@@ -723,8 +686,20 @@ func (r *DatabaseClusterRestoreReconciler) ReconcileWatchers(ctx context.Context
 	}
 
 	log := log.FromContext(ctx)
-	addWatcher := func(dbEngineType everestv1alpha1.EngineType, obj client.Object, f func(context.Context, client.Object) error) error {
-		if err := r.controller.addWatchers(string(dbEngineType), source.Kind(r.Cache, obj, r.watchHandler(f))); err != nil {
+	addWatcher := func(dbEngineType everestv1alpha1.EngineType, obj client.Object) error {
+		// This source is the same as calling Owns() on the controller builder.
+		// I.e, &DatabaseClusterRestore{} owns obj.
+		src := source.Kind(
+			r.Cache,
+			obj,
+			handler.EnqueueRequestForOwner(
+				r.Scheme,
+				r.RESTMapper(),
+				&everestv1alpha1.DatabaseClusterRestore{},
+				handler.OnlyControllerOwner(),
+			),
+		)
+		if err := r.controller.addWatchers(string(dbEngineType), src); err != nil {
 			return err
 		}
 		return nil
@@ -736,15 +711,15 @@ func (r *DatabaseClusterRestoreReconciler) ReconcileWatchers(ctx context.Context
 		}
 		switch t := dbEngine.Spec.Type; t {
 		case everestv1alpha1.DatabaseEnginePXC:
-			if err := addWatcher(t, &pxcv1.PerconaXtraDBClusterRestore{}, nil); err != nil {
+			if err := addWatcher(t, &pxcv1.PerconaXtraDBClusterRestore{}); err != nil {
 				return err
 			}
 		case everestv1alpha1.DatabaseEnginePostgresql:
-			if err := addWatcher(t, &pgv2.PerconaPGRestore{}, r.tryCreatePG); err != nil {
+			if err := addWatcher(t, &pgv2.PerconaPGRestore{}); err != nil {
 				return err
 			}
 		case everestv1alpha1.DatabaseEnginePSMDB:
-			if err := addWatcher(t, &psmdbv1.PerconaServerMongoDBRestore{}, nil); err != nil {
+			if err := addWatcher(t, &psmdbv1.PerconaServerMongoDBRestore{}); err != nil {
 				return err
 			}
 		default:
@@ -753,132 +728,4 @@ func (r *DatabaseClusterRestoreReconciler) ReconcileWatchers(ctx context.Context
 		}
 	}
 	return nil
-}
-
-func (r *DatabaseClusterRestoreReconciler) watchHandler(creationFunc func(ctx context.Context, obj client.Object) error) handler.Funcs { //nolint:dupl
-	return handler.Funcs{
-		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			r.tryCreateDBRestore(ctx, e.Object, creationFunc)
-			q.Add(reconcileRequestFromObject(e.Object))
-		},
-		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			r.tryCreateDBRestore(ctx, e.ObjectNew, creationFunc)
-			q.Add(reconcileRequestFromObject(e.ObjectNew))
-		},
-		DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			r.tryDeleteDBRestore(ctx, e.Object)
-			q.Add(reconcileRequestFromObject(e.Object))
-		},
-	}
-}
-
-func (r *DatabaseClusterRestoreReconciler) tryCreateDBRestore(
-	ctx context.Context,
-	obj client.Object,
-	createRestoreFunc func(ctx context.Context, obj client.Object) error,
-) {
-	if createRestoreFunc == nil {
-		return
-	}
-	logger := log.FromContext(ctx)
-	if len(obj.GetOwnerReferences()) == 0 {
-		err := createRestoreFunc(ctx, obj)
-		if err != nil {
-			logger.Error(err, "Failed to create DatabaseClusterRestore "+obj.GetName())
-		}
-	}
-}
-
-func (r *DatabaseClusterRestoreReconciler) tryCreatePG(ctx context.Context, obj client.Object) error {
-	pgRestore := &pgv2.PerconaPGRestore{}
-	namespacedName := types.NamespacedName{
-		Namespace: obj.GetNamespace(),
-		Name:      obj.GetName(),
-	}
-
-	if err := r.Get(ctx, namespacedName, pgRestore); err != nil {
-		// if such upstream restore is not found - do nothing
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	pg := &pgv2.PerconaPGCluster{}
-	if err := r.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: pgRestore.Spec.PGCluster}, pg); err != nil {
-		// if such upstream cluster is not found - do nothing
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	storages := &everestv1alpha1.BackupStorageList{}
-	if err := r.List(ctx, storages, &client.ListOptions{Namespace: namespacedName.Namespace}); err != nil {
-		// if no backup storages found - do nothing
-		if k8serrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	restore := &everestv1alpha1.DatabaseClusterRestore{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      obj.GetName(),
-			Namespace: obj.GetNamespace(),
-		},
-	}
-
-	err := r.Get(ctx, namespacedName, restore)
-	// if such everest restore already exists - do nothing
-	if err == nil {
-		return nil
-	}
-	if !k8serrors.IsNotFound(err) {
-		return err
-	}
-
-	restore.Spec.DBClusterName = pgRestore.Spec.PGCluster
-
-	cluster := &everestv1alpha1.DatabaseCluster{}
-	err = r.Get(ctx, types.NamespacedName{Name: pgRestore.Spec.PGCluster, Namespace: pgRestore.Namespace}, cluster)
-	if err != nil {
-		return err
-	}
-	name, nErr := backupStorageName(pgRestore.Spec.RepoName, pg, storages)
-	if nErr != nil {
-		return nErr
-	}
-
-	restore.Spec.DataSource.BackupSource = &everestv1alpha1.BackupSource{
-		Path:              "",
-		BackupStorageName: name,
-	}
-	restore.ObjectMeta.Labels = map[string]string{
-		databaseClusterNameLabel: pgRestore.Spec.PGCluster,
-	}
-	if err = controllerutil.SetControllerReference(cluster, restore, r.Scheme); err != nil {
-		return err
-	}
-
-	return r.Create(ctx, restore)
-}
-
-func (r *DatabaseClusterRestoreReconciler) tryDeleteDBRestore(ctx context.Context, obj client.Object) {
-	logger := log.FromContext(ctx)
-	name := obj.GetName()
-	namespace := obj.GetNamespace()
-	dbr := &everestv1alpha1.DatabaseClusterRestore{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-	}
-
-	if err := r.Delete(ctx, dbr); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return
-		}
-		logger.Error(err, "Failed to delete the DatabaseClusterRestore", "name", name, "namespace", namespace)
-	}
 }

--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -50,12 +50,6 @@ const (
 	pgBackRestStorageVerifyTmpl    = "%s-storage-verify-tls"
 	pgBackRestStorageForcePathTmpl = "%s-s3-uri-style"
 	pgBackRestStoragePathStyle     = "path"
-	repo1Name                      = "repo1"
-)
-
-var (
-	errDataSourceNotFound               = errors.New("data source is not found")
-	errBackupSourceNotFoundInDataSource = errors.New("no backup storage found in data source")
 )
 
 type applier struct {
@@ -623,7 +617,8 @@ func (p *applier) genPGDataSourceSpec() (*crunchyv1beta1.DataSource, error) {
 		return nil, err
 	}
 
-	options, err := getPGRestoreOptions(*database.Spec.DataSource, backupStorage, backupBaseName, repo1Name)
+	repoName := "repo1"
+	options, err := getPGRestoreOptions(*database.Spec.DataSource, backupStorage, backupBaseName, repoName)
 	if err != nil {
 		return nil, err
 	}
@@ -632,7 +627,7 @@ func (p *applier) genPGDataSourceSpec() (*crunchyv1beta1.DataSource, error) {
 	pgDataSource := &crunchyv1beta1.DataSource{
 		PGBackRest: &crunchyv1beta1.PGBackRestDataSource{
 			Global: map[string]string{
-				fmt.Sprintf(pgBackRestPathTmpl, repo1Name): globalDatasourceDestination(dest, database, backupStorage),
+				fmt.Sprintf(pgBackRestPathTmpl, repoName): globalDatasourceDestination(dest, database, backupStorage),
 			},
 			Stanza:  "db",
 			Options: options,
@@ -649,11 +644,11 @@ func (p *applier) genPGDataSourceSpec() (*crunchyv1beta1.DataSource, error) {
 	// Handle PG Datasource based on the backup storage type.
 	switch backupStorage.Spec.Type {
 	case everestv1alpha1.BackupStorageTypeS3:
-		if err := p.handlePGDataSourceS3(repo1Name, pgDataSource, backupStorage, database); err != nil {
+		if err := p.handlePGDataSourceS3(repoName, pgDataSource, backupStorage, database); err != nil {
 			return nil, err
 		}
 	case everestv1alpha1.BackupStorageTypeAzure:
-		if err := p.handlePGDataSourceAzure(repo1Name, pgDataSource, backupStorage, database); err != nil {
+		if err := p.handlePGDataSourceAzure(repoName, pgDataSource, backupStorage, database); err != nil {
 			return nil, err
 		}
 	default:
@@ -798,14 +793,14 @@ func (p *applier) createPGBackrestSecret(
 }
 
 // Add backup storages used by restores to the list.
-func addBackupStoragesByRestores(
-	ctx context.Context,
-	c client.Client,
+func (p *applier) addBackupStoragesByRestores(
 	backupList *everestv1alpha1.DatabaseClusterBackupList,
 	restoreList *everestv1alpha1.DatabaseClusterRestoreList,
 	backupStorages map[string]everestv1alpha1.BackupStorage,
 	backupStoragesSecrets map[string]*corev1.Secret,
 ) error {
+	ctx := p.ctx
+	c := p.C
 	for _, restore := range restoreList.Items {
 		// If the restore has already completed, skip it.
 		if restore.IsComplete() {
@@ -875,14 +870,14 @@ func addBackupStoragesByRestores(
 }
 
 // Add backup storages used by backup schedules to the list.
-func addBackupStoragesBySchedules(
-	ctx context.Context,
-	c client.Client,
-	database *everestv1alpha1.DatabaseCluster,
+func (p *applier) addBackupStoragesBySchedules(
 	backupSchedules []everestv1alpha1.BackupSchedule,
 	backupStorages map[string]everestv1alpha1.BackupStorage,
 	backupStoragesSecrets map[string]*corev1.Secret,
 ) error {
+	ctx := p.ctx
+	database := p.DB
+	c := p.C
 	// Add backup storages used by backup schedules to the list
 	for _, schedule := range backupSchedules {
 		// Check if we already fetched that backup storage
@@ -908,13 +903,13 @@ func addBackupStoragesBySchedules(
 }
 
 // Add backup storages used by on-demand backups to the list.
-func addBackupStoragesByOnDemandBackups(
-	ctx context.Context,
-	c client.Client,
+func (p *applier) addBackupStoragesByOnDemandBackups(
 	backupList *everestv1alpha1.DatabaseClusterBackupList,
 	backupStorages map[string]everestv1alpha1.BackupStorage,
 	backupStoragesSecrets map[string]*corev1.Secret,
 ) error {
+	ctx := p.ctx
+	c := p.C
 	for _, backup := range backupList.Items {
 		// Check if we already fetched that backup storage
 		if _, ok := backupStorages[backup.Spec.BackupStorageName]; ok {
@@ -965,50 +960,53 @@ func (p *applier) reconcilePGBackupsSpec() (pgv2.Backups, error) {
 		// internally and sets the
 		// postgres-operator.crunchydata.com/pgbackrest-backup annotation.
 		newBackups.PGBackRest.Manual = &crunchyv1beta1.PGBackRestManualBackup{
-			RepoName: repo1Name,
+			RepoName: "repo1",
 		}
 	}
 
-	var (
-		pgBackrestRepos      []crunchyv1beta1.PGBackRestRepo
-		pgBackrestGlobal     map[string]string
-		pgBackrestSecretData []byte
-		err                  error
+	// List DatabaseClusterBackup objects for this database
+	backupList, err := common.DatabaseClusterBackupsThatReferenceObject(ctx, c, common.DBClusterBackupDBClusterNameField, database.GetNamespace(), database.Name)
+	if err != nil {
+		return pgv2.Backups{}, err
+	}
+
+	backupStorages := map[string]everestv1alpha1.BackupStorage{}
+	backupStoragesSecrets := map[string]*corev1.Secret{}
+
+	// Add backup storages used by on-demand backups to the list
+	if err := p.addBackupStoragesByOnDemandBackups(backupList, backupStorages, backupStoragesSecrets); err != nil {
+		return pgv2.Backups{}, err
+	}
+
+	// List DatabaseClusterRestore objects for this database
+	restoreList, err := common.DatabaseClusterRestoresThatReferenceObject(ctx, c, common.DBClusterBackupDBClusterNameField, database.GetNamespace(), database.GetName())
+	if err != nil {
+		return pgv2.Backups{}, err
+	}
+
+	// Add backup storages used by restores to the list
+	if err := p.addBackupStoragesByRestores(backupList, restoreList, backupStorages, backupStoragesSecrets); err != nil {
+		return pgv2.Backups{}, err
+	}
+
+	backupSchedules := database.Spec.Backup.Schedules
+
+	// Add backup storages used by backup schedules to the list
+	if err := p.addBackupStoragesBySchedules(backupSchedules, backupStorages, backupStoragesSecrets); err != nil {
+		return pgv2.Backups{}, err
+	}
+
+	pgBackrestRepos, pgBackrestGlobal, pgBackrestSecretData, err := reconcilePGBackRestRepos(
+		oldBackups.PGBackRest.Repos,
+		backupSchedules,
+		backupList.Items,
+		backupStorages,
+		backupStoragesSecrets,
+		database.Spec.Engine.Storage,
+		database,
 	)
-
-	// If DataSource is not empty, it means the "restore to a new cluster" is happening.
-	// The DataSource storage is placed into repo1.
-	// All other storages (e.g. from schedules) are ignored until the restoration is complete (Everest deletes the DataSource once restoration is complete)
-	// to prevent buckets duplication in pg repos.
-	backupStorage, backupStorageSecret, err := getDataSourceStorage(ctx, c, database)
-	if err == nil {
-		pgBackrestRepos, pgBackrestGlobal, pgBackrestSecretData, err = reconcileDataSourceRepo(
-			backupStorage,
-			backupStorageSecret,
-			database,
-		)
-		if err != nil {
-			return pgv2.Backups{}, err
-		}
-	}
-	// if there was no DataSource - reconcile as usual
-	if errors.Is(err, errDataSourceNotFound) {
-		backupStorages, backupStoragesSecrets, backups, err := getRelatedStorages(ctx, c, database)
-		if err != nil {
-			return pgv2.Backups{}, err
-		}
-		pgBackrestRepos, pgBackrestGlobal, pgBackrestSecretData, err = reconcilePGBackRestRepos(
-			oldBackups.PGBackRest.Repos,
-			database.Spec.Backup.Schedules,
-			backups,
-			backupStorages,
-			backupStoragesSecrets,
-			database.Spec.Engine.Storage,
-			database,
-		)
-		if err != nil {
-			return pgv2.Backups{}, err
-		}
+	if err != nil {
+		return pgv2.Backups{}, err
 	}
 
 	pgBackrestSecret, err := createPGBackrestSecret(
@@ -1037,84 +1035,6 @@ func (p *applier) reconcilePGBackupsSpec() (pgv2.Backups, error) {
 	newBackups.PGBackRest.Repos = pgBackrestRepos
 	newBackups.PGBackRest.Global = pgBackrestGlobal
 	return newBackups, nil
-}
-
-func getDataSourceStorage(ctx context.Context, c client.Client, db *everestv1alpha1.DatabaseCluster) (*everestv1alpha1.BackupStorage, *corev1.Secret, error) {
-	if db.Spec.DataSource == nil {
-		return nil, nil, errDataSourceNotFound
-	}
-	var dataSourceStorageName string
-	if db.Spec.DataSource.DBClusterBackupName != "" {
-		backup := &everestv1alpha1.DatabaseClusterBackup{}
-		err := c.Get(ctx, types.NamespacedName{Name: db.Spec.DataSource.DBClusterBackupName, Namespace: db.Namespace}, backup)
-		if err != nil {
-			return nil, nil, err
-		}
-		dataSourceStorageName = backup.Spec.BackupStorageName
-	} else {
-		dataSourceStorageName = db.Spec.DataSource.BackupSource.BackupStorageName
-	}
-
-	if dataSourceStorageName == "" {
-		return nil, nil, errBackupSourceNotFoundInDataSource
-	}
-
-	backupStorage := &everestv1alpha1.BackupStorage{}
-	err := c.Get(ctx, types.NamespacedName{Name: dataSourceStorageName, Namespace: db.Namespace}, backupStorage)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	backupStorageSecret := &corev1.Secret{}
-	key := types.NamespacedName{Name: backupStorage.Spec.CredentialsSecretName, Namespace: backupStorage.GetNamespace()}
-	err = c.Get(ctx, key, backupStorageSecret)
-	if err != nil {
-		return nil, nil, err
-	}
-	return backupStorage, backupStorageSecret, nil
-}
-
-func getRelatedStorages(
-	ctx context.Context,
-	c client.Client,
-	db *everestv1alpha1.DatabaseCluster,
-) (
-	map[string]everestv1alpha1.BackupStorage,
-	map[string]*corev1.Secret,
-	[]everestv1alpha1.DatabaseClusterBackup,
-	error,
-) {
-	backupStorages := map[string]everestv1alpha1.BackupStorage{}
-	backupStoragesSecrets := map[string]*corev1.Secret{}
-
-	backupList, err := common.DatabaseClusterBackupsThatReferenceObject(ctx, c, common.DBClusterBackupDBClusterNameField, db.GetNamespace(), db.GetName())
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	// Add backup storages used by on-demand backups to the list
-	if err = addBackupStoragesByOnDemandBackups(ctx, c, backupList, backupStorages, backupStoragesSecrets); err != nil {
-		return nil, nil, nil, err
-	}
-
-	// List DatabaseClusterRestore objects for this database
-	restoreList, err := common.DatabaseClusterRestoresThatReferenceObject(ctx, c, common.DBClusterRestoreDBClusterNameField, db.GetNamespace(), db.GetName())
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	// Add backup storages used by restores to the list
-	if err = addBackupStoragesByRestores(ctx, c, backupList, restoreList, backupStorages, backupStoragesSecrets); err != nil {
-		return nil, nil, nil, err
-	}
-
-	backupSchedules := db.Spec.Backup.Schedules
-
-	// Add backup storages used by backup schedules to the list
-	if err = addBackupStoragesBySchedules(ctx, c, db, backupSchedules, backupStorages, backupStoragesSecrets); err != nil {
-		return nil, nil, nil, err
-	}
-	return backupStorages, backupStoragesSecrets, backupList.Items, nil
 }
 
 // createPGBackrestSecret creates or updates the PG Backrest secret.
@@ -1152,38 +1072,6 @@ func createPGBackrestSecret(
 	}
 
 	return pgBackrestSecret, nil
-}
-
-// When the restoring from DataSource is in progress, only the repo DataSource repo (repo1) is reconciled.
-// When the restoring process is complete, all the repos start to reconcile again as usual.
-func reconcileDataSourceRepo(
-	bs *everestv1alpha1.BackupStorage,
-	bsSecret *corev1.Secret,
-	db *everestv1alpha1.DatabaseCluster,
-) (
-	[]crunchyv1beta1.PGBackRestRepo,
-	map[string]string,
-	[]byte,
-	error,
-) {
-	// create the pg reconciler as if we didn't have any repos and schedules to reconcile only the dataSource repo
-	reposReconciler, err := newPGReposReconciler([]crunchyv1beta1.PGBackRestRepo{}, []everestv1alpha1.BackupSchedule{})
-	if err != nil {
-		return []crunchyv1beta1.PGBackRestRepo{}, map[string]string{}, []byte{},
-			errors.Join(err, errors.New("failed to initialize PGBackrest repos reconciler"))
-	}
-
-	newRepos, err := reposReconciler.addDataSourceRepo(db, bs, bsSecret)
-	if err != nil {
-		return []crunchyv1beta1.PGBackRestRepo{}, map[string]string{}, []byte{}, err
-	}
-
-	pgBackrestIniBytes, err := reposReconciler.pgBackRestIniBytes()
-	if err != nil {
-		return []crunchyv1beta1.PGBackRestRepo{}, map[string]string{}, []byte{}, err
-	}
-
-	return newRepos, reposReconciler.pgBackRestGlobal, pgBackrestIniBytes, nil
 }
 
 func reconcilePGBackRestRepos(

--- a/internal/controller/providers/pg/pg_repos_reconciler.go
+++ b/internal/controller/providers/pg/pg_repos_reconciler.go
@@ -43,8 +43,6 @@ type pgReposReconciler struct {
 	reposToBeReconciled           *list.List
 }
 
-const maxStorages = 4
-
 func newPGReposReconciler(oldRepos []crunchyv1beta1.PGBackRestRepo, backupSchedules []everestv1alpha1.BackupSchedule) (*pgReposReconciler, error) {
 	iniFile, err := ini.Load([]byte{})
 	if err != nil {
@@ -62,7 +60,10 @@ func newPGReposReconciler(oldRepos []crunchyv1beta1.PGBackRestRepo, backupSchedu
 		backupSchedulesToBeReconciled.PushBack(backupSchedule)
 	}
 
-	const maxPGBackrestOptionsNumber = 150 // the full potential list https://pgbackrest.org/configuration.html
+	const (
+		maxStorages                = 4
+		maxPGBackrestOptionsNumber = 150 // the full potential list https://pgbackrest.org/configuration.html
+	)
 
 	pgBackRestGlobal := make(map[string]string, maxPGBackrestOptionsNumber*maxStorages)
 	pgBackRestGlobal["repo1-retention-full"] = "1"
@@ -407,7 +408,7 @@ func (p *pgReposReconciler) addDefaultRepo(engineStorage everestv1alpha1.Storage
 	// cluster if the only repo in the list is changed.
 	newRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name: repo1Name,
+			Name: "repo1",
 			Volume: &crunchyv1beta1.RepoPVC{
 				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
 					AccessModes: []corev1.PersistentVolumeAccessMode{
@@ -434,27 +435,6 @@ func (p *pgReposReconciler) addDefaultRepo(engineStorage everestv1alpha1.Storage
 	}
 	sortByName(newRepos)
 	return newRepos, nil
-}
-
-func (p *pgReposReconciler) addDataSourceRepo(
-	db *everestv1alpha1.DatabaseCluster,
-	bs *everestv1alpha1.BackupStorage,
-	bsSecret *corev1.Secret,
-) ([]crunchyv1beta1.PGBackRestRepo, error) {
-	repo := crunchyv1beta1.PGBackRestRepo{
-		Name: repo1Name,
-		S3: &crunchyv1beta1.RepoS3{
-			Bucket:   bs.Spec.Bucket,
-			Endpoint: bs.Spec.EndpointURL,
-			Region:   bs.Spec.Region,
-		},
-	}
-	p.addRepoToPGGlobal(bs.Spec.VerifyTLS, repo.Name, bs.Spec.ForcePathStyle, pointer.ToInt32(0), db)
-	err := updatePGIni(p.pgBackRestSecretIni, bsSecret, repo)
-	if err != nil {
-		return nil, errors.Join(err, errors.New("failed to add backup storage credentials to PGBackrest secret data"))
-	}
-	return []crunchyv1beta1.PGBackRestRepo{repo}, nil
 }
 
 func sortByName(repos []crunchyv1beta1.PGBackRestRepo) {

--- a/internal/controller/providers/pg/pg_test.go
+++ b/internal/controller/providers/pg/pg_test.go
@@ -247,10 +247,28 @@ func TestReconcilePGBackRestReposEmptyAddRequest(t *testing.T) {
 			},
 		},
 	}
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -311,10 +329,28 @@ func TestReconcilePGBackRestReposEmptyAddSchedule(t *testing.T) {
 			},
 		},
 	}
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -349,10 +385,24 @@ func TestReconcilePGBackRestReposEmptyAddSchedule(t *testing.T) {
 
 func TestReconcilePGBackRestReposSameStorageOneRequestAddRequest(t *testing.T) {
 	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -394,10 +444,26 @@ func TestReconcilePGBackRestReposSameStorageOneRequestAddRequest(t *testing.T) {
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -429,10 +495,24 @@ func TestReconcilePGBackRestReposSameStorageOneRequestAddRequest(t *testing.T) {
 
 func TestReconcilePGBackRestReposSameStorageOneRequestAddSchedule(t *testing.T) {
 	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -477,10 +557,26 @@ func TestReconcilePGBackRestReposSameStorageOneRequestAddSchedule(t *testing.T) 
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -516,10 +612,24 @@ func TestReconcilePGBackRestReposSameStorageOneRequestAddSchedule(t *testing.T) 
 func TestReconcilePGBackRestReposSameStorageOneScheduleAddRequest(t *testing.T) {
 	t.Parallel()
 	testSchedule := "0 0 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -566,10 +676,26 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleAddRequest(t *testing.T) 
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -606,10 +732,24 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleAddSchedule(t *testing.T)
 	t.Parallel()
 	testSchedule1 := "0 0 * * *"
 	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -656,10 +796,26 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleAddSchedule(t *testing.T)
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -706,10 +862,24 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleAddSchedule(t *testing.T)
 func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddRequest(t *testing.T) {
 	t.Parallel()
 	testSchedule := "0 0 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -770,10 +940,26 @@ func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddRequest(t *testin
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -818,10 +1004,24 @@ func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddSchedule(t *testi
 	t.Parallel()
 	testSchedule1 := "0 0 * * *"
 	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -882,10 +1082,26 @@ func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddSchedule(t *testi
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -933,10 +1149,24 @@ func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddScheduleNoOrder(t
 	t.Parallel()
 	testSchedule1 := "0 0 * * *"
 	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo3",
@@ -997,10 +1227,26 @@ func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddScheduleNoOrder(t
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1047,10 +1293,24 @@ func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddScheduleNoOrder(t
 func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddRequestNoOrder(t *testing.T) {
 	t.Parallel()
 	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo3",
@@ -1111,10 +1371,26 @@ func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddRequestNoOrder(t 
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1159,10 +1435,24 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleChangeSchedule(t *testing
 	t.Parallel()
 	testSchedule1 := "0 0 * * *"
 	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1203,10 +1493,26 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleChangeSchedule(t *testing
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1244,10 +1550,24 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleChangeScheduleAddSchedule
 	testSchedule1 := "0 0 * * *"
 	testSchedule2 := "0 1 * * *"
 	testSchedule3 := "0 2 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1294,10 +1614,26 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleChangeScheduleAddSchedule
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1344,10 +1680,24 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleChangeScheduleAddSchedule
 func TestReconcilePGBackRestReposSameStorageOneScheduleDeleteScheduleAddRequest(t *testing.T) {
 	t.Parallel()
 	testSchedule := "0 0 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1387,10 +1737,26 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleDeleteScheduleAddRequest(
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1424,10 +1790,24 @@ func TestReconcilePGBackRestReposSameStorageTwoSchedulesDelete2ndSchedule(t *tes
 	t.Parallel()
 	testSchedule1 := "0 0 * * *"
 	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1479,10 +1859,26 @@ func TestReconcilePGBackRestReposSameStorageTwoSchedulesDelete2ndSchedule(t *tes
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1519,10 +1915,24 @@ func TestReconcilePGBackRestReposSameStorageTwoSchedulesDelete1stSchedule(t *tes
 	t.Parallel()
 	testSchedule1 := "0 0 * * *"
 	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1574,10 +1984,26 @@ func TestReconcilePGBackRestReposSameStorageTwoSchedulesDelete1stSchedule(t *tes
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo3",
@@ -1613,10 +2039,24 @@ func TestReconcilePGBackRestReposSameStorageTwoSchedulesDelete1stSchedule(t *tes
 func TestReconcilePGBackRestReposOneScheduleDeleteSchedule(t *testing.T) {
 	t.Parallel()
 	testSchedule1 := "0 0 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1634,10 +2074,26 @@ func TestReconcilePGBackRestReposOneScheduleDeleteSchedule(t *testing.T) {
 	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
 	testBackupStorages := map[string]everestv1alpha1.BackupStorage{}
 	testBackupStoragesSecrets := map[string]*corev1.Secret{}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -1661,10 +2117,24 @@ func TestReconcilePGBackRestReposOneScheduleDeleteSchedule(t *testing.T) {
 
 func TestReconcilePGBackRestReposOneRequestDeleteRequest(t *testing.T) {
 	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1679,10 +2149,26 @@ func TestReconcilePGBackRestReposOneRequestDeleteRequest(t *testing.T) {
 	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
 	testBackupStorages := map[string]everestv1alpha1.BackupStorage{}
 	testBackupStoragesSecrets := map[string]*corev1.Secret{}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -1710,10 +2196,24 @@ func TestReconcilePGBackRestReposSameStorageThreeSchedulesAddSchedule(t *testing
 	testSchedule2 := "0 1 * * *"
 	testSchedule3 := "0 2 * * *"
 	testSchedule4 := "0 3 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1794,6 +2294,10 @@ func TestReconcilePGBackRestReposSameStorageThreeSchedulesAddSchedule(t *testing
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{}
 
 	repos, _, _, err := reconcilePGBackRestRepos(
@@ -1816,10 +2320,24 @@ func TestReconcilePGBackRestReposSameStorageThreeSchedulesAddSchedule(t *testing
 
 func TestReconcilePGBackRestReposDifferentStorageThreeRequestsAddRequest(t *testing.T) {
 	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -1929,6 +2447,10 @@ func TestReconcilePGBackRestReposDifferentStorageThreeRequestsAddRequest(t *test
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{}
 
 	repos, _, _, err := reconcilePGBackRestRepos(
@@ -1954,10 +2476,24 @@ func TestReconcilePGBackRestReposSameStorageThreeSchedulesAddRequest(t *testing.
 	testSchedule1 := "0 0 * * *"
 	testSchedule2 := "0 1 * * *"
 	testSchedule3 := "0 2 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -2038,10 +2574,26 @@ func TestReconcilePGBackRestReposSameStorageThreeSchedulesAddRequest(t *testing.
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -2109,6 +2661,12 @@ func TestReconcilePGBackRestReposUnknownStorageRequest(t *testing.T) {
 	}
 	testBackupStorages := map[string]everestv1alpha1.BackupStorage{}
 	testBackupStoragesSecrets := map[string]*corev1.Secret{}
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{}
 
 	repos, _, _, err := reconcilePGBackRestRepos(
@@ -2131,13 +2689,14 @@ func TestReconcilePGBackRestReposUnknownStorageRequest(t *testing.T) {
 
 func TestReconcilePGBackRestReposScheduleAfterOnDemandToAnotherStorage(t *testing.T) {
 	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	s3Repo2 := &crunchyv1beta1.RepoS3{
 		Bucket: "bucket1",
 	}
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
 		},
 		{
 			Name: "repo2",
@@ -2182,10 +2741,26 @@ func TestReconcilePGBackRestReposScheduleAfterOnDemandToAnotherStorage(t *testin
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -2221,13 +2796,14 @@ func TestReconcilePGBackRestReposScheduleAfterOnDemandToAnotherStorage(t *testin
 
 func TestReconcilePGBackRestReposOnDemandAfterScheduleToAnotherStorage(t *testing.T) {
 	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	s3Repo2 := &crunchyv1beta1.RepoS3{
 		Bucket: "bucket1",
 	}
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
 		},
 		{
 			Name: "repo2",
@@ -2275,10 +2851,26 @@ func TestReconcilePGBackRestReposOnDemandAfterScheduleToAnotherStorage(t *testin
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -2314,6 +2906,8 @@ func TestReconcilePGBackRestReposOnDemandAfterScheduleToAnotherStorage(t *testin
 
 func TestReconcilePGBackRestReposScheduleAfter3OnDemands(t *testing.T) {
 	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	s3Repo2 := &crunchyv1beta1.RepoS3{
 		Bucket: "bucket1",
 	}
@@ -2325,8 +2919,7 @@ func TestReconcilePGBackRestReposScheduleAfter3OnDemands(t *testing.T) {
 	}
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
 		},
 		{
 			Name: "repo2",
@@ -2403,10 +2996,26 @@ func TestReconcilePGBackRestReposScheduleAfter3OnDemands(t *testing.T) {
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -2444,6 +3053,8 @@ func TestReconcilePGBackRestReposScheduleAfter3OnDemands(t *testing.T) {
 
 func TestReconcilePGBackRestReposOnDemand3OnDemandsAndSchedule(t *testing.T) {
 	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	s3Repo2 := &crunchyv1beta1.RepoS3{
 		Bucket: "bucket1",
 	}
@@ -2455,8 +3066,7 @@ func TestReconcilePGBackRestReposOnDemand3OnDemandsAndSchedule(t *testing.T) {
 	}
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
 		},
 		{
 			Name: "repo2",
@@ -2541,10 +3151,26 @@ func TestReconcilePGBackRestReposOnDemand3OnDemandsAndSchedule(t *testing.T) {
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -2582,13 +3208,14 @@ func TestReconcilePGBackRestReposOnDemand3OnDemandsAndSchedule(t *testing.T) {
 
 func TestReconcilePGBackRestBackupAndScheduleToTheSameStorage(t *testing.T) {
 	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	s3Repo2 := &crunchyv1beta1.RepoS3{
 		Bucket: "bucket1",
 	}
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
 		},
 		{
 			Name: "repo2",
@@ -2627,10 +3254,26 @@ func TestReconcilePGBackRestBackupAndScheduleToTheSameStorage(t *testing.T) {
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -2660,13 +3303,14 @@ func TestReconcilePGBackRestBackupAndScheduleToTheSameStorage(t *testing.T) {
 
 func TestReconcilePGBackRestNewBackupAndNewScheduleToTheSameStorage(t *testing.T) {
 	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	s3Repo2 := &crunchyv1beta1.RepoS3{
 		Bucket: "bucket1",
 	}
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
 		},
 	}
 	testBackupSchedules := []everestv1alpha1.BackupSchedule{{
@@ -2698,10 +3342,26 @@ func TestReconcilePGBackRestNewBackupAndNewScheduleToTheSameStorage(t *testing.T
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -2729,210 +3389,16 @@ func TestReconcilePGBackRestNewBackupAndNewScheduleToTheSameStorage(t *testing.T
 	assert.Equal(t, expRepos, repos)
 }
 
-func TestReconcilePGBackRestRestoreFromDataSource_NoSchedules_NoBackups(t *testing.T) {
-	t.Parallel()
-
-	testRepos := []crunchyv1beta1.PGBackRestRepo{
-		{
-			Name: "repo1",
-			S3:   &crunchyv1beta1.RepoS3{}, // some s3 storage in repo1 means the cluster was freshly restored from source
-		},
-	}
-	var testBackupSchedules []everestv1alpha1.BackupSchedule
-	var testBackupRequests []everestv1alpha1.DatabaseClusterBackup
-	testBackupStorages := map[string]everestv1alpha1.BackupStorage{} // does not matter because no schedules no backups
-	testBackupStoragesSecrets := map[string]*corev1.Secret{}         // does not matter because no schedules no backups
-	expRepos := []crunchyv1beta1.PGBackRestRepo{
-		{
-			Name:   "repo1",
-			Volume: pvcVolume,
-		},
-	}
-
-	repos, _, _, _ := reconcilePGBackRestRepos( //nolint:dogsled
-		testRepos,
-		testBackupSchedules,
-		testBackupRequests,
-		testBackupStorages,
-		testBackupStoragesSecrets,
-		testEngineStorage,
-		&everestv1alpha1.DatabaseCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test",
-				UID:  "123",
-			},
-		},
-	)
-	assert.Equal(t, expRepos, repos)
-}
-
-func TestReconcilePGBackRestRestoreFromDataSource_1Schedule_1Backup_SameStorage(t *testing.T) {
-	t.Parallel()
-	testRepos := []crunchyv1beta1.PGBackRestRepo{
-		{
-			Name: "repo1",
-			S3:   &crunchyv1beta1.RepoS3{}, // some s3 storage in repo1 means the cluster was freshly restored from source
-		},
-	}
-	testBackupSchedules := []everestv1alpha1.BackupSchedule{{
-		Enabled:           true,
-		Name:              "sched1",
-		Schedule:          "20 * * * *",
-		BackupStorageName: "bs1",
-	}}
-	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
-		{
-			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
-				BackupStorageName: "bs1",
-			},
-		},
-	}
-	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-		"bs1": {
-			Spec: everestv1alpha1.BackupStorageSpec{
-				Type:   "s3",
-				Bucket: "bucket1",
-			},
-		},
-	}
-	testBackupStoragesSecrets := map[string]*corev1.Secret{
-		"bs1": {
-			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
-				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
-			},
-		},
-	}
-	expRepos := []crunchyv1beta1.PGBackRestRepo{
-		{
-			Name:   "repo1",
-			Volume: pvcVolume,
-		},
-		{
-			Name: "repo2",
-			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
-				Full: pointer.To("20 * * * *"),
-			},
-			S3: &crunchyv1beta1.RepoS3{
-				Bucket: "bucket1",
-			},
-		},
-	}
-
-	repos, _, _, _ := reconcilePGBackRestRepos( //nolint:dogsled
-		testRepos,
-		testBackupSchedules,
-		testBackupRequests,
-		testBackupStorages,
-		testBackupStoragesSecrets,
-		testEngineStorage,
-		&everestv1alpha1.DatabaseCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test",
-				UID:  "123",
-			},
-		},
-	)
-	assert.Equal(t, expRepos, repos)
-}
-
-func TestReconcilePGBackRestRestoreFromDataSource_1Schedule_1Backup_DifferentStorage(t *testing.T) {
-	t.Parallel()
-	testRepos := []crunchyv1beta1.PGBackRestRepo{
-		{
-			Name: "repo1",
-			S3:   &crunchyv1beta1.RepoS3{}, // some s3 storage in repo1 means the cluster was freshly restored from source
-		},
-	}
-	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
-		{
-			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
-				BackupStorageName: "bs1",
-			},
-		},
-	}
-	testBackupSchedules := []everestv1alpha1.BackupSchedule{{
-		Enabled:           true,
-		Name:              "sched1",
-		Schedule:          "20 * * * *",
-		BackupStorageName: "bs2",
-	}}
-	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-		"bs1": {
-			Spec: everestv1alpha1.BackupStorageSpec{
-				Type:   "s3",
-				Bucket: "bucket1",
-			},
-		},
-		"bs2": {
-			Spec: everestv1alpha1.BackupStorageSpec{
-				Type:   "s3",
-				Bucket: "bucket2",
-			},
-		},
-	}
-	testBackupStoragesSecrets := map[string]*corev1.Secret{
-		"bs1": {
-			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
-				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
-			},
-		},
-		"bs2": {
-			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
-				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
-			},
-		},
-	}
-	expRepos := []crunchyv1beta1.PGBackRestRepo{
-		{
-			Name:   "repo1",
-			Volume: pvcVolume,
-		},
-		{
-			Name: "repo2",
-			S3: &crunchyv1beta1.RepoS3{
-				Bucket: "bucket1",
-			},
-		},
-		{
-			Name: "repo3",
-			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
-				Full: pointer.To("20 * * * *"),
-			},
-			S3: &crunchyv1beta1.RepoS3{
-				Bucket: "bucket2",
-			},
-		},
-	}
-
-	repos, _, _, _ := reconcilePGBackRestRepos( //nolint:dogsled
-		testRepos,
-		testBackupSchedules,
-		testBackupRequests,
-		testBackupStorages,
-		testBackupStoragesSecrets,
-		testEngineStorage,
-		&everestv1alpha1.DatabaseCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test",
-				UID:  "123",
-			},
-		},
-	)
-	assert.Equal(t, expRepos, repos)
-}
-
 func TestReconcilePGBackRestBackupAndNewScheduleToTheSameStorage(t *testing.T) {
 	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
 	s3Repo2 := &crunchyv1beta1.RepoS3{
 		Bucket: "bucket1",
 	}
 	testRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
 		},
 		{
 			Name: "repo2",
@@ -2968,10 +3434,26 @@ func TestReconcilePGBackRestBackupAndNewScheduleToTheSameStorage(t *testing.T) {
 			},
 		},
 	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "repo2",
@@ -3014,7 +3496,12 @@ func TestReconcilePGBackRestReposUnknownStorageSchedule(t *testing.T) {
 	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
 	testBackupStorages := map[string]everestv1alpha1.BackupStorage{}
 	testBackupStoragesSecrets := map[string]*corev1.Secret{}
-
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{}
 
 	repos, _, _, err := reconcilePGBackRestRepos(
@@ -3042,11 +3529,28 @@ func TestReconcilePGBackRestReposEmpty(t *testing.T) {
 	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
 	testBackupStorages := map[string]everestv1alpha1.BackupStorage{}
 	testBackupStoragesSecrets := map[string]*corev1.Secret{}
-
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
 	expRepos := []crunchyv1beta1.PGBackRestRepo{
 		{
-			Name:   "repo1",
-			Volume: pvcVolume,
+			Name: "repo1",
+			Volume: &crunchyv1beta1.RepoPVC{
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					StorageClassName: &testEngineStorageClass,
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: testEngineStorageSize,
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -3163,96 +3667,5 @@ func TestSortPGBackRestReposByName(t *testing.T) {
 		input := tc.repos
 		sortByName(input)
 		assert.Equal(t, input, tc.sortedRepos)
-	}
-}
-
-var pvcVolume, testEngineStorage = pvcVolumeAndEngineStorage()
-
-func pvcVolumeAndEngineStorage() (*crunchyv1beta1.RepoPVC, everestv1alpha1.Storage) {
-	testEngineStorageSize, _ := resource.ParseQuantity("15G")
-	testEngineStorageClass := "someSC"
-	testEngineStorage := everestv1alpha1.Storage{
-		Size:  testEngineStorageSize,
-		Class: &testEngineStorageClass,
-	}
-	return &crunchyv1beta1.RepoPVC{
-		VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
-			AccessModes: []corev1.PersistentVolumeAccessMode{
-				corev1.ReadWriteOnce,
-			},
-			StorageClassName: &testEngineStorageClass,
-			Resources: corev1.VolumeResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: testEngineStorageSize,
-				},
-			},
-		},
-	}, testEngineStorage
-}
-
-func TestReconcileDataSourceRepo(t *testing.T) {
-	t.Parallel()
-	type testCase struct {
-		name     string
-		bs       *everestv1alpha1.BackupStorage
-		bsSecret *corev1.Secret
-		db       *everestv1alpha1.DatabaseCluster
-
-		err              error
-		pgBackrestGlobal map[string]string
-		expRepos         []crunchyv1beta1.PGBackRestRepo
-	}
-
-	storage1 := &everestv1alpha1.BackupStorage{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "bs1",
-		},
-		Spec: everestv1alpha1.BackupStorageSpec{
-			Type:        "S3",
-			Bucket:      "bucket1",
-			Region:      "region",
-			EndpointURL: "https://url.com",
-		},
-	}
-	testCases := []testCase{
-		{
-			name: "add storage to repo1",
-			bs:   storage1,
-			bsSecret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bs1_secret",
-				},
-			},
-			db: &everestv1alpha1.DatabaseCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "db1",
-					UID:  "uid1",
-				},
-			},
-			pgBackrestGlobal: map[string]string{"repo1-path": "/db1/uid1", "repo1-retention-full": "9999999", "repo1-s3-uri-style": "path", "repo1-storage-verify-tls": "n"},
-			expRepos: []crunchyv1beta1.PGBackRestRepo{{
-				Name: "repo1",
-				S3: &crunchyv1beta1.RepoS3{
-					Bucket:   storage1.Spec.Bucket,
-					Endpoint: storage1.Spec.EndpointURL,
-					Region:   storage1.Spec.Region,
-				},
-			}},
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			repos, pgBackrestGlobal, _, err := reconcileDataSourceRepo(
-				tc.bs,
-				tc.bsSecret,
-				tc.db,
-			)
-			if tc.err == nil {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, tc.expRepos, repos)
-			assert.Equal(t, tc.pgBackrestGlobal, pgBackrestGlobal)
-		})
 	}
 }

--- a/internal/controller/providers/pg/provider.go
+++ b/internal/controller/providers/pg/provider.go
@@ -200,9 +200,6 @@ func (p *Provider) Status(ctx context.Context) (everestv1alpha1.DatabaseClusterS
 func isPVCResizing(ctx context.Context, c client.Client, name, namespace string) (bool, error) {
 	pg := &crunchyv1beta1.PostgresCluster{}
 	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, pg); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return false, nil
-		}
 		return false, fmt.Errorf("failed to get PostgreSQL cluster: %w", err)
 	}
 


### PR DESCRIPTION
**Revert #752**
---
**Problem:**
EVEREST-1012

https://github.com/percona/everest-operator/pull/752 was merged by a mistake without QA. During QA there were several updates implemented in https://github.com/percona/everest-operator/pull/784 then other tickets were prioritised over this one and this ticket was moved back to `Ready for QA`, got stuck there and still not merged. 
As a result, the fix version for the ticket was changed from `1.8.0` to `1.9.0`, so this PR reverts the original PR https://github.com/percona/everest-operator/pull/752 so that we could have `1.8.0` without any changes related to this ticket.  

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
