### PR TITLE
EVEREST-2155 | Check if DataImportJob payload Secret exists before attempting to reconcile it

### DIFF
--- a/internal/controller/dataimportjob_controller.go
+++ b/internal/controller/dataimportjob_controller.go
@@ -276,7 +276,7 @@ func (r *DataImportJobReconciler) ensureDataImportPayloadSecret(
 	}
 
 	// If the Secret already exists with the desired key, we will not attempt create it again.
-	// Typically we should actively reconcile the controlled objects actively, but in this case
+	// Typically we should actively reconcile the controlled objects, but in this case
 	// we do not expect the contents of the Secret to change at all so its okay to skip it, unless
 	// the Secret or its data are missing altogether.
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(secret), secret); err == nil {

--- a/internal/controller/dataimportjob_controller.go
+++ b/internal/controller/dataimportjob_controller.go
@@ -275,6 +275,18 @@ func (r *DataImportJobReconciler) ensureDataImportPayloadSecret(
 		},
 	}
 
+	// If the Secret already exists with the desired key, we will not attempt create it again.
+	// Typically we should actively reconcile the controlled objects actively, but in this case
+	// we do not expect the contents of the Secret to change at all so its okay to skip it, unless
+	// the Secret or its data are missing altogether.
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(secret), secret); err == nil {
+		if val, ok := secret.Data[dataImportJSONSecretKey]; ok && len(val) > 0 {
+			return nil
+		}
+	} else if client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("failed to get data import request secret: %w", err)
+	}
+
 	req := dataimporterspec.Spec{}
 
 	dbUser, dbPassword, err := r.getDBRootUserCredentials(ctx, db)

--- a/internal/controller/dataimportjob_controller.go
+++ b/internal/controller/dataimportjob_controller.go
@@ -279,6 +279,8 @@ func (r *DataImportJobReconciler) ensureDataImportPayloadSecret(
 	// Typically we should actively reconcile the controlled objects, but in this case
 	// we do not expect the contents of the Secret to change at all so its okay to skip it, unless
 	// the Secret or its data are missing altogether.
+	// Moreover, even if the Secret does change, there's nothing that the DataImporter can do
+	// because it has already started with the initially provided details.
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(secret), secret); err == nil {
 		if val, ok := secret.Data[dataImportJSONSecretKey]; ok && len(val) > 0 {
 			return nil


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-2155

The PG DataImportJob remains in `Error` state for a long time before eventually transitioning to `Succeeded`

**Cause:**
* The PG DataImportJob "re-creates" the upstream `PerconaPGCluster` object
* As a part of this re-creation, the user Secret temporarily goes missing (PG operator deletes it)
* The DataImportJob Controller tries to actively reconcile a payload Secret for which it requires this user secret. If this user secret is missing, it complains and moves to `Error`
* The Secret is eventually created, so the job then transitions to `Succeeded`

**Solution:**
* Do not attempt to reconcile the request payload Secret if it already exists with the desired keys. This payload Secret is already created once during the job initialisation, so we know it contains the correct info.
* While controllers are typically expected to actively reconcile the objects, its okay to skip in this case because we do not expect this Secret content to change once created (this payload contains details such as S3 credentials, DB info, etc. that do not change). Moreover, even if the Secret does change, there's nothing that the DataImporter can do because it has already started with the initially provided details.
* Since the DataImportJob controller now no longer cares if the Secret is already exists, it will not move the DataImportJob object to an `Error` state

> NOTE: If a user manually deletes this payload Secret, we run into the same problem, but we don't expect anyone or anything to try and delete it. So this should be an acceptable trade-off.

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
