### PR TITLE
EVEREST-2148 | improve secret copying logic when restoring to new DB

### DIFF
--- a/internal/controller/databasecluster_controller.go
+++ b/internal/controller/databasecluster_controller.go
@@ -470,6 +470,7 @@ func (r *DatabaseClusterReconciler) copyCredentialsFromDBBackup(
 	}
 
 	prevSecretName := sourceDB.Spec.Engine.UserSecretsName
+
 	prevSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      prevSecretName,
@@ -481,6 +482,7 @@ func (r *DatabaseClusterReconciler) copyCredentialsFromDBBackup(
 	}
 
 	newSecretName := db.Spec.Engine.UserSecretsName
+
 	newSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      newSecretName,


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-2148

This problem was initially discovered during testing of data importer, when the UI created the user credentials secret using a different naming format from everest-operator (`everest-secrests-xx`)

When a different naming format was used by the UI for the creation of this secret, restore into new DB would fail.

**Cause:**
The copy/restore to new DB logic requires the original user secret from the source DB to be copied. However, it searches for the secret based on a hard-coded naming format rather than looking it up from the DB spec.

**Solution:**
Instead of assuming a certain naming format for the secret, it should lookup the actual name of the source secret from the DB spec.

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
