### PR TITLE
EVEREST-2177 Add initContainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG FLAGS
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -28,7 +29,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o data-importer internal/data-importer/main.go
 
 # Build migration binary
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o migrator internal/migrate/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags "${FLAGS}" -o migrator internal/migrate/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,16 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 # Build data importer CLI
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o data-importer internal/data-importer/main.go
 
+# Build migration binary
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o migrator internal/migrate/main.go
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/data-importer .
+COPY --from=builder /workspace/migrator .
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/manager", "/migrator"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ COPY --from=builder /workspace/data-importer .
 COPY --from=builder /workspace/migrator .
 USER 65532:65532
 
-ENTRYPOINT ["/manager", "/migrator"]
+ENTRYPOINT ["/manager"]

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -457,8 +457,6 @@ spec:
               - command:
                 - /migrator
                 env:
-                - name: EVEREST_VERSION
-                  value: latest
                 - name: SYSTEM_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -78,7 +78,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-08-11T15:06:24Z"
+    createdAt: "2025-08-21T07:02:37Z"
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: everest-operator.v0.0.0
@@ -453,6 +453,20 @@ spec:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: webhook-certs
                   readOnly: true
+              initContainers:
+              - command:
+                - /migrator
+                env:
+                - name: EVEREST_VERSION
+                  value: latest
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                image: docker.io/perconalab/everest-operator:0.0.0
+                imagePullPolicy: IfNotPresent
+                name: crs-migration
+                resources: {}
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: everest-operator-controller-manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,8 +60,6 @@ spec:
       initContainers:
         - name: crs-migration
           env:
-            - name: EVEREST_VERSION
-              value: latest
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -57,6 +57,19 @@ spec:
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         # seccompProfile:
         #   type: RuntimeDefault
+      initContainers:
+        - name: crs-migration
+          env:
+            - name: EVEREST_VERSION
+              value: latest
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          image: controller:latest
+          command:
+            - /migrator
+          imagePullPolicy: IfNotPresent
       containers:
       - command:
         - /manager

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -9231,6 +9231,19 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-certs
           readOnly: true
+      initContainers:
+      - command:
+        - /migrator
+        env:
+        - name: EVEREST_VERSION
+          value: latest
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/perconalab/everest-operator:0.0.0
+        imagePullPolicy: IfNotPresent
+        name: crs-migration
       securityContext:
         runAsNonRoot: true
       serviceAccountName: everest-operator-controller-manager

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -9235,8 +9235,6 @@ spec:
       - command:
         - /migrator
         env:
-        - name: EVEREST_VERSION
-          value: latest
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:

--- a/internal/consts/version.go
+++ b/internal/consts/version.go
@@ -15,5 +15,5 @@
 
 package consts
 
-// Version is a component version e.g. v1.9.0-rc1
+// Version is a component version e.g. v1.9.0-rc1.
 var Version string //nolint:gochecknoglobals

--- a/internal/consts/version.go
+++ b/internal/consts/version.go
@@ -1,0 +1,19 @@
+// everest-operator
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consts
+
+// Version is a component version e.g. v1.9.0-rc1
+var Version string //nolint:gochecknoglobals

--- a/internal/controller/common/helper.go
+++ b/internal/controller/common/helper.go
@@ -121,28 +121,20 @@ func GetOperatorVersion(
 // GetClusterType returns the type of the cluster on which this operator is running.
 func GetClusterType(ctx context.Context, c client.Client) (consts.ClusterType, error) {
 	clusterType := consts.ClusterTypeMinikube
-	unstructuredResource := &unstructured.Unstructured{}
-	unstructuredResource.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "storage.k8s.io",
-		Kind:    "StorageClass",
-		Version: "v1",
-	})
 	storageList := &storagev1.StorageClassList{}
 
-	err := c.List(ctx, unstructuredResource)
+	err := c.List(ctx, storageList)
 	if err != nil {
 		return clusterType, err
 	}
-	err = runtime.DefaultUnstructuredConverter.
-		FromUnstructured(unstructuredResource.Object, storageList)
-	if err != nil {
-		return clusterType, err
-	}
+
 	for _, storage := range storageList.Items {
 		if strings.Contains(storage.Provisioner, "aws") {
 			clusterType = consts.ClusterTypeEKS
+			break
 		}
 	}
+
 	return clusterType, nil
 }
 

--- a/internal/migrate/main.go
+++ b/internal/migrate/main.go
@@ -1,0 +1,77 @@
+// everest-operator
+// Copyright (C) 2022 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/percona/everest-operator/internal/migrate/migrator"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+/*
+How to test migrations locally.
+Tilt installation does not contain the migration initContainer. To test the migration locally:
+
+1. everest-operator Makefile has 2 make targets "k3d-cluster-up" and "k3d-cluster-down" which you can use to setup/tear down k3d clusters
+2. Use the make target "docker-build" to locally build a percona/everest-operator:0.0.0 image based off your local code changes
+3. Use the make target "k3d-upload-image" to copy the locally built docker image onto the k3d cluster
+4. Install dev-latest normally, either via Helm or everestctl. It will use the locally copied 0.0.0 image instead of the one from Docker.
+   	helm local installation example:
+		$ cd percona-helm-charts/charts/everest
+		$ helm install everest . --namespace everest-system --create-namespace
+When you need to re-build the code, simply run step 2 and 3 and restart the everest-operator manually
+*/
+
+func main() {
+	pCtx := context.Background()
+	ctx, stop := signal.NotifyContext(pCtx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	root.SetContext(ctx)
+	if err := root.Execute(); err != nil {
+		panic(err)
+	}
+}
+
+var root = &cobra.Command{
+	Use: "migrator",
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := zap.New(zap.UseDevMode(true))
+		m, err := migrator.NewMigrator(logger)
+		if err != nil {
+			logger.Error(err, "failed to create migrator")
+			os.Exit(1)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		err, info := m.Migrate(ctx)
+		if err != nil {
+			logger.Error(err, "failed to migrate")
+			os.Exit(1)
+		}
+		if info != "" {
+			logger.Info(info)
+		}
+	},
+}

--- a/internal/migrate/main.go
+++ b/internal/migrate/main.go
@@ -22,9 +22,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/percona/everest-operator/internal/migrate/migrator"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/percona/everest-operator/internal/migrate/migrator"
 )
 
 /*

--- a/internal/migrate/migrator/migrator.go
+++ b/internal/migrate/migrator/migrator.go
@@ -39,7 +39,6 @@ import (
 
 const (
 	systemNamespaceEnvVar              = "SYSTEM_NAMESPACE"
-	versionEnvVar                      = "EVEREST_VERSION"
 	leaseName                          = "everest-migration-lease"
 	lastMigrationVersionAnnotationName = "last-migration-version"
 	defaultEKSLoadBalancerConfigName   = "eks-default"
@@ -55,9 +54,10 @@ type Migrator struct {
 
 // NewMigrator creates a new migrator.
 func NewMigrator(logger logr.Logger) (*Migrator, error) {
+	logger.Info("Initializing Migrator", "currentVersion", consts.Version)
 	m := &Migrator{
 		l:               logger,
-		currentVersion:  os.Getenv(versionEnvVar),
+		currentVersion:  consts.Version,
 		systemNamespace: os.Getenv(systemNamespaceEnvVar),
 	}
 

--- a/internal/migrate/migrator/migrator.go
+++ b/internal/migrate/migrator/migrator.go
@@ -1,3 +1,18 @@
+// everest-operator
+// Copyright (C) 2025 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package migrator
 
 import (

--- a/internal/migrate/migrator/migrator.go
+++ b/internal/migrate/migrator/migrator.go
@@ -73,7 +73,7 @@ func NewMigrator(logger logr.Logger) (*Migrator, error) {
 
 // Migrate function that performs CRs migration.
 func (m *Migrator) Migrate(ctx context.Context) (info string, rerr error) { //nolint:nonamedreturns
-	lease, err := m.getLease(ctx)
+	lease, err := m.createLeaseIfNotExists(ctx)
 	if err != nil {
 		return "", fmt.Errorf("unable to prepare lease: %w", err)
 	}
@@ -113,7 +113,7 @@ func (m *Migrator) BuildScheme() *runtime.Scheme {
 	return scheme
 }
 
-func (m *Migrator) getLease(ctx context.Context) (*v1.Lease, error) {
+func (m *Migrator) createLeaseIfNotExists(ctx context.Context) (*v1.Lease, error) {
 	meta := metav1.ObjectMeta{
 		Name:      leaseName,
 		Namespace: m.systemNamespace,

--- a/internal/migrate/migrator/migrator_test.go
+++ b/internal/migrate/migrator/migrator_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/coordination/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +35,7 @@ import (
 const everestSystemNs = "everest-system"
 
 func TestMigrateNonAWS(t *testing.T) {
+	t.Parallel()
 	m := Migrator{
 		l:               zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)),
 		currentVersion:  "0.0.0",
@@ -42,16 +44,18 @@ func TestMigrateNonAWS(t *testing.T) {
 	m.client = fake.NewClientBuilder().WithScheme(m.BuildScheme()).Build()
 	ctx := context.Background()
 
-	err, info := m.Migrate(ctx)
+	info, err := m.Migrate(ctx)
 	// check the migration is not performed on cluster types other than EKS
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "cluster type is not EKS, applying empty migration", info)
 
 	// check the Lease is created and contains the current version
-	checkLeaseIsCreatedAndUpdated(t, m, ctx)
+	checkLeaseIsCreatedAndUpdated(ctx, t, m)
 }
 
 func TestMigrateAWSNoDBs(t *testing.T) {
+	t.Parallel()
+
 	storageClassAWS := storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "aws-storage"},
 		Provisioner: "kubernetes.io/aws-ebs",
@@ -70,15 +74,17 @@ func TestMigrateAWSNoDBs(t *testing.T) {
 
 	ctx := context.Background()
 
-	err, info := m.Migrate(ctx)
+	info, err := m.Migrate(ctx)
 	// check the migration is performed successfully
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "migration is performed successfully", info)
 
-	checkLeaseIsCreatedAndUpdated(t, m, ctx)
+	checkLeaseIsCreatedAndUpdated(ctx, t, m)
 }
 
 func TestMigrateAWSAlreadyPerformed(t *testing.T) {
+	t.Parallel()
+
 	storageClassAWS := storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "aws-storage"},
 		Provisioner: "kubernetes.io/aws-ebs",
@@ -107,13 +113,15 @@ func TestMigrateAWSAlreadyPerformed(t *testing.T) {
 	m.client = fake.NewClientBuilder().WithScheme(m.BuildScheme()).WithLists(&storageClassList).WithObjects(&lease).Build()
 	ctx := context.Background()
 
-	err, info := m.Migrate(ctx)
+	info, err := m.Migrate(ctx)
 	// check we detected that migration is already performed
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "migration is already performed", info)
 }
 
 func TestMigrateAWSNonExposedClusters(t *testing.T) {
+	t.Parallel()
+
 	storageClassAWS := storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "aws-storage"},
 		Provisioner: "kubernetes.io/aws-ebs",
@@ -149,12 +157,12 @@ func TestMigrateAWSNonExposedClusters(t *testing.T) {
 
 	ctx := context.Background()
 
-	err, info := m.Migrate(ctx)
-	assert.Nil(t, err)
+	info, err := m.Migrate(ctx)
+	require.NoError(t, err)
 	assert.Equal(t, "migration is performed successfully", info)
 
 	// check the Lease is created and updated with the current version
-	checkLeaseIsCreatedAndUpdated(t, m, ctx)
+	checkLeaseIsCreatedAndUpdated(ctx, t, m)
 
 	// check that the default LoadBalancerConfigName is not assigned
 	updatedDB := &v1alpha1.DatabaseCluster{}
@@ -162,12 +170,14 @@ func TestMigrateAWSNonExposedClusters(t *testing.T) {
 		Name:      "db1",
 		Namespace: ns,
 	}, updatedDB, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, db1.Name, updatedDB.Name)
-	assert.Equal(t, "", updatedDB.Spec.Proxy.Expose.LoadBalancerConfigName)
+	assert.Empty(t, updatedDB.Spec.Proxy.Expose.LoadBalancerConfigName)
 }
 
 func TestMigrateAWSExposedClusters(t *testing.T) {
+	t.Parallel()
+
 	storageClassAWS := storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "aws-storage"},
 		Provisioner: "kubernetes.io/aws-ebs",
@@ -203,30 +213,33 @@ func TestMigrateAWSExposedClusters(t *testing.T) {
 
 	ctx := context.Background()
 
-	err, info := m.Migrate(ctx)
-	assert.Nil(t, err)
+	info, err := m.Migrate(ctx)
+	require.NoError(t, err)
 	assert.Equal(t, "migration is performed successfully", info)
 
 	// check the Lease is created and updated with the current version
-	checkLeaseIsCreatedAndUpdated(t, m, ctx)
+	checkLeaseIsCreatedAndUpdated(ctx, t, m)
 
 	// check that the default LoadBalancerConfigName is assigned
 	updatedDB := &v1alpha1.DatabaseCluster{}
-	m.client.Get(ctx, types.NamespacedName{
+	err = m.client.Get(ctx, types.NamespacedName{
 		Name:      "db1",
 		Namespace: ns,
 	}, updatedDB, nil)
+	require.NoError(t, err)
 	assert.Equal(t, db1.Name, updatedDB.Name)
 	assert.Equal(t, defaultEKSLoadBalancerConfigName, updatedDB.Spec.Proxy.Expose.LoadBalancerConfigName)
 }
 
-func checkLeaseIsCreatedAndUpdated(t *testing.T, m Migrator, ctx context.Context) {
+func checkLeaseIsCreatedAndUpdated(ctx context.Context, t *testing.T, m Migrator) {
 	// check the Lease is created and contains the current version
+	t.Helper()
+
 	lease := &v1.Lease{}
 	err := m.client.Get(ctx, types.NamespacedName{
 		Name:      leaseName,
 		Namespace: everestSystemNs,
 	}, lease, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, map[string]string{lastMigrationVersionAnnotationName: "0.0.0"}, lease.Annotations)
 }

--- a/internal/migrate/migrator/migrator_test.go
+++ b/internal/migrate/migrator/migrator_test.go
@@ -1,3 +1,18 @@
+// everest-operator
+// Copyright (C) 2025 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package migrator
 
 import (

--- a/internal/migrate/migrator/migrator_test.go
+++ b/internal/migrate/migrator/migrator_test.go
@@ -1,0 +1,217 @@
+package migrator
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/coordination/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/percona/everest-operator/api/v1alpha1"
+)
+
+const everestSystemNs = "everest-system"
+
+func TestMigrateNonAWS(t *testing.T) {
+	m := Migrator{
+		l:               zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)),
+		currentVersion:  "0.0.0",
+		systemNamespace: everestSystemNs,
+	}
+	m.client = fake.NewClientBuilder().WithScheme(m.BuildScheme()).Build()
+	ctx := context.Background()
+
+	err, info := m.Migrate(ctx)
+	// check the migration is not performed on cluster types other than EKS
+	assert.NoError(t, err)
+	assert.Equal(t, "cluster type is not EKS, applying empty migration", info)
+
+	// check the Lease is created and contains the current version
+	checkLeaseIsCreatedAndUpdated(t, m, ctx)
+}
+
+func TestMigrateAWSNoDBs(t *testing.T) {
+	storageClassAWS := storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: "aws-storage"},
+		Provisioner: "kubernetes.io/aws-ebs",
+	}
+	storageClassList := storagev1.StorageClassList{
+		TypeMeta: metav1.TypeMeta{},
+		ListMeta: metav1.ListMeta{},
+		Items:    []storagev1.StorageClass{storageClassAWS},
+	}
+	m := Migrator{
+		l:               zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)),
+		currentVersion:  "0.0.0",
+		systemNamespace: "everest-system",
+	}
+	m.client = fake.NewClientBuilder().WithScheme(m.BuildScheme()).WithLists(&storageClassList).Build()
+
+	ctx := context.Background()
+
+	err, info := m.Migrate(ctx)
+	// check the migration is performed successfully
+	assert.Nil(t, err)
+	assert.Equal(t, "migration is performed successfully", info)
+
+	checkLeaseIsCreatedAndUpdated(t, m, ctx)
+}
+
+func TestMigrateAWSAlreadyPerformed(t *testing.T) {
+	storageClassAWS := storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: "aws-storage"},
+		Provisioner: "kubernetes.io/aws-ebs",
+	}
+	storageClassList := storagev1.StorageClassList{
+		TypeMeta: metav1.TypeMeta{},
+		ListMeta: metav1.ListMeta{},
+		Items:    []storagev1.StorageClass{storageClassAWS},
+	}
+	// already have a lease with the same last migration version
+	lease := v1.Lease{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      leaseName,
+			Namespace: everestSystemNs,
+			Annotations: map[string]string{
+				lastMigrationVersionAnnotationName: "0.0.0",
+			},
+		},
+	}
+	m := Migrator{
+		l:               zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)),
+		currentVersion:  "0.0.0",
+		systemNamespace: "everest-system",
+	}
+	m.client = fake.NewClientBuilder().WithScheme(m.BuildScheme()).WithLists(&storageClassList).WithObjects(&lease).Build()
+	ctx := context.Background()
+
+	err, info := m.Migrate(ctx)
+	// check we detected that migration is already performed
+	assert.Nil(t, err)
+	assert.Equal(t, "migration is already performed", info)
+}
+
+func TestMigrateAWSNonExposedClusters(t *testing.T) {
+	storageClassAWS := storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: "aws-storage"},
+		Provisioner: "kubernetes.io/aws-ebs",
+	}
+	storageClassList := storagev1.StorageClassList{
+		TypeMeta: metav1.TypeMeta{},
+		ListMeta: metav1.ListMeta{},
+		Items:    []storagev1.StorageClass{storageClassAWS},
+	}
+	ns := "ns1"
+	db1 := v1alpha1.DatabaseCluster{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "db1",
+			Namespace: ns,
+		},
+		Spec: v1alpha1.DatabaseClusterSpec{
+			Proxy: v1alpha1.Proxy{
+				Expose: v1alpha1.Expose{
+					Type: "internal",
+				},
+			},
+		},
+		Status: v1alpha1.DatabaseClusterStatus{},
+	}
+
+	m := Migrator{
+		l:               zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)),
+		currentVersion:  "0.0.0",
+		systemNamespace: "everest-system",
+	}
+	m.client = fake.NewClientBuilder().WithScheme(m.BuildScheme()).WithLists(&storageClassList).WithObjects(&db1).Build()
+
+	ctx := context.Background()
+
+	err, info := m.Migrate(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "migration is performed successfully", info)
+
+	// check the Lease is created and updated with the current version
+	checkLeaseIsCreatedAndUpdated(t, m, ctx)
+
+	// check that the default LoadBalancerConfigName is not assigned
+	updatedDB := &v1alpha1.DatabaseCluster{}
+	err = m.client.Get(ctx, types.NamespacedName{
+		Name:      "db1",
+		Namespace: ns,
+	}, updatedDB, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, db1.Name, updatedDB.Name)
+	assert.Equal(t, "", updatedDB.Spec.Proxy.Expose.LoadBalancerConfigName)
+}
+
+func TestMigrateAWSExposedClusters(t *testing.T) {
+	storageClassAWS := storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: "aws-storage"},
+		Provisioner: "kubernetes.io/aws-ebs",
+	}
+	storageClassList := storagev1.StorageClassList{
+		TypeMeta: metav1.TypeMeta{},
+		ListMeta: metav1.ListMeta{},
+		Items:    []storagev1.StorageClass{storageClassAWS},
+	}
+	ns := "ns1"
+	db1 := v1alpha1.DatabaseCluster{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "db1",
+			Namespace: ns,
+		},
+		Spec: v1alpha1.DatabaseClusterSpec{
+			Proxy: v1alpha1.Proxy{
+				Expose: v1alpha1.Expose{
+					Type: "external",
+				},
+			},
+		},
+		Status: v1alpha1.DatabaseClusterStatus{},
+	}
+
+	m := Migrator{
+		l:               zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)),
+		currentVersion:  "0.0.0",
+		systemNamespace: "everest-system",
+	}
+	m.client = fake.NewClientBuilder().WithScheme(m.BuildScheme()).WithLists(&storageClassList).WithObjects(&db1).Build()
+
+	ctx := context.Background()
+
+	err, info := m.Migrate(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "migration is performed successfully", info)
+
+	// check the Lease is created and updated with the current version
+	checkLeaseIsCreatedAndUpdated(t, m, ctx)
+
+	// check that the default LoadBalancerConfigName is assigned
+	updatedDB := &v1alpha1.DatabaseCluster{}
+	m.client.Get(ctx, types.NamespacedName{
+		Name:      "db1",
+		Namespace: ns,
+	}, updatedDB, nil)
+	assert.Equal(t, db1.Name, updatedDB.Name)
+	assert.Equal(t, defaultEKSLoadBalancerConfigName, updatedDB.Spec.Proxy.Expose.LoadBalancerConfigName)
+}
+
+func checkLeaseIsCreatedAndUpdated(t *testing.T, m Migrator, ctx context.Context) {
+	// check the Lease is created and contains the current version
+	lease := &v1.Lease{}
+	err := m.client.Get(ctx, types.NamespacedName{
+		Name:      leaseName,
+		Namespace: everestSystemNs,
+	}, lease, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{lastMigrationVersionAnnotationName: "0.0.0"}, lease.Annotations)
+}

--- a/internal/migrate/migrator/migrator_test.go
+++ b/internal/migrate/migrator/migrator_test.go
@@ -36,6 +36,7 @@ const everestSystemNs = "everest-system"
 
 func TestMigrateNonAWS(t *testing.T) {
 	t.Parallel()
+
 	m := Migrator{
 		l:               zap.New(zap.UseDevMode(true), zap.WriteTo(os.Stdout)),
 		currentVersion:  "0.0.0",

--- a/internal/migrate/migrator/migrator_test.go
+++ b/internal/migrate/migrator/migrator_test.go
@@ -17,7 +17,7 @@ package migrator
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"testing"
 
@@ -265,6 +265,6 @@ type failingClient struct {
 	client.Client
 }
 
-func (f *failingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	return fmt.Errorf("simulated update failure")
+func (f *failingClient) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	return errors.New("simulated update failure")
 }

--- a/internal/webhooks/databasecluster.go
+++ b/internal/webhooks/databasecluster.go
@@ -188,7 +188,9 @@ func (v *DatabaseClusterValidator) ValidateLoadBalancerConfig(ctx context.Contex
 	if lbcName == "" {
 		return nil
 	}
+
 	lbc := everestv1alpha1.LoadBalancerConfig{}
+
 	err := v.Client.Get(ctx, client.ObjectKey{
 		Name: lbcName,
 	}, &lbc)
@@ -196,6 +198,7 @@ func (v *DatabaseClusterValidator) ValidateLoadBalancerConfig(ctx context.Contex
 		if k8serrors.IsNotFound(err) {
 			return fmt.Errorf("load balancer config %s not found: %w", lbcName, err)
 		}
+
 		return fmt.Errorf("failed to get load balancer config %s: %w", lbcName, err)
 	}
 

--- a/internal/webhooks/load_balancer_config.go
+++ b/internal/webhooks/load_balancer_config.go
@@ -21,6 +21,7 @@ package webhooks
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -93,7 +94,7 @@ func (v *LoadBalancerConfigValidator) ValidateUpdate(ctx context.Context, oldObj
 		return nil, errUnexpectedObject(newObj)
 	}
 
-	if utils.IsEverestReadOnlyObject(oldLbc) {
+	if utils.IsEverestReadOnlyObject(oldLbc) && !reflect.DeepEqual(oldLbc.Spec, newLbc.Spec) {
 		// default config update is not allowed
 		return nil, errUpdateDefaultLBC(newLbc.Name)
 	}

--- a/utils/finalizers.go
+++ b/utils/finalizers.go
@@ -1,34 +1,3 @@
-// everest-operator
-// // everest-operator
-// // Copyright (C) 2022 Percona LLC
-// //
-// // Licensed under the Apache License, Version 2.0 (the "License");
-// // you may not use this file except in compliance with the License.
-// // You may obtain a copy of the License at
-// //
-// // http://www.apache.org/licenses/LICENSE-2.0
-// //
-// // Unless required by applicable law or agreed to in writing, software
-// // distributed under the License is distributed on an "AS IS" BASIS,
-// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// // See the License for the specific language governing permissions and
-// // limitations under the License.
-
-// // everest-operator
-// // Copyright (C) 2022 Percona LLC
-// //
-// // Licensed under the Apache License, Version 2.0 (the "License");
-// // you may not use this file except in compliance with the License.
-// // You may obtain a copy of the License at
-// //
-// // http://www.apache.org/licenses/LICENSE-2.0
-// //
-// // Unless required by applicable law or agreed to in writing, software
-// // distributed under the License is distributed on an "AS IS" BASIS,
-// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// // See the License for the specific language governing permissions and
-// // limitations under the License.
-
 // Copyright (C) 2025 Percona LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utils/finalizers.go
+++ b/utils/finalizers.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+package utils //nolint:revive
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/utils/finalizers.go
+++ b/utils/finalizers.go
@@ -1,3 +1,4 @@
+// everest-operator
 // Copyright (C) 2025 Percona LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/utils/validators.go
+++ b/utils/validators.go
@@ -31,7 +31,7 @@ var (
 
 	// ErrNameNotRFC1035Compatible appears when some of the provided names are not RFC1035 compatible.
 	ErrNameNotRFC1035Compatible = func(fieldName string) error {
-		return fmt.Errorf(`'%s' is not RFC 1035 compatible. The name should contain only lowercase alphanumeric characters or '-', start with an alphabetic character, end with an alphanumeric character`,
+		return fmt.Errorf(`'%s' is not RFC 1035 compatible. The name should contain only lowercase alphanumeric characters or '-', start with an alphabetic character, end with an alphanumeric character`, //nolint:lll
 			fieldName,
 		)
 	}

--- a/utils/validators_test.go
+++ b/utils/validators_test.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 // Package utils contains common utils
-package utils //nolint:revive
+package utils
 
 import (
 	"testing"

--- a/utils/validators_test.go
+++ b/utils/validators_test.go
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+// Package utils contains common utils
+package utils //nolint:revive
 
 import (
 	"testing"
@@ -21,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateRFC1035(t *testing.T) {
+func TestValidateRFC1035(t *testing.T) { //nolint:dupl
 	t.Parallel()
 
 	type testCase struct {
@@ -90,7 +91,7 @@ func TestValidateRFC1035(t *testing.T) {
 	}
 }
 
-func TestValidateResourceName(t *testing.T) {
+func TestValidateResourceName(t *testing.T) { //nolint:dupl
 	t.Parallel()
 
 	type testCase struct {


### PR DESCRIPTION
**Add the migrator initContainer**
---
**Problem:**
EVEREST-2177

In this PR:

1. **Added a new binary for migrator** 
Migrator is included as a separate binary with its own endpoint into the everest-operator image. Everest-operator now has initContainer that always tries to run the migrator. The migrator uses the Lease object to track wether the migration was already done (by checking annotations which contain the last version) and if so it does nothing. If the migration wasn't done, the migrator checks if the k8s type is EKS and if so - adds the loadBalancerConfigName = "eks-default" to all exposed DB clusters. 

3. **Removed the "Unstructured" layer.**  
Previously when Everest was checking the k8s type it was getting the `StorageClassList` using `Unstructured`. It was so seems the very beginning. After a research it seems to me that there is no actual need to use it, we can get the `StorageClassList` directly. My assumption that it was so to support the very old k8s types, which we don't support in Everest anyway yet. I removed this `Unstructured` layer because it complicates unit-testing a lot.


**Related pull requests**

- https://github.com/percona/everest/pull/1590
- https://github.com/percona/percona-helm-charts/pull/617

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
