### PR TITLE
EVEREST-2224 | remove selectableFields from PSP CRD

### DIFF
--- a/api/v1alpha1/podschedulingpolicy_types.go
+++ b/api/v1alpha1/podschedulingpolicy_types.go
@@ -78,7 +78,6 @@ type PodSchedulingPolicyStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,path=podschedulingpolicies,shortName=psp
-// +kubebuilder:selectablefield:JSONPath=".spec.engineType"
 // +kubebuilder:printcolumn:name="Engine",type="string",JSONPath=".spec.engineType",description="DB engine type the policy can be applied to"
 // +kubebuilder:printcolumn:name="InUse",type="string",JSONPath=".status.inUse",description="Indicates if the policy is used by any DB cluster"
 

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -78,7 +78,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-07-29T10:45:34Z"
+    createdAt: "2025-08-21T11:21:02Z"
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: everest-operator.v0.0.0

--- a/bundle/manifests/everest.percona.com_podschedulingpolicies.yaml
+++ b/bundle/manifests/everest.percona.com_podschedulingpolicies.yaml
@@ -6574,8 +6574,6 @@ spec:
                 type: integer
             type: object
         type: object
-    selectableFields:
-    - jsonPath: .spec.engineType
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/everest.percona.com_podschedulingpolicies.yaml
+++ b/config/crd/bases/everest.percona.com_podschedulingpolicies.yaml
@@ -6574,8 +6574,6 @@ spec:
                 type: integer
             type: object
         type: object
-    selectableFields:
-    - jsonPath: .spec.engineType
     served: true
     storage: true
     subresources:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -8323,8 +8323,6 @@ spec:
                 type: integer
             type: object
         type: object
-    selectableFields:
-    - jsonPath: .spec.engineType
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-2224

Installation on older versions fails as CRD field selectors are not enabled by default.

**Solution:**
Remove `selectableFields` since it is not used anywhere

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
