### PR TITLE
EVEREST-2217 | Use APIReader for fetching MonitoringConfig Secret in validation webhook

### DIFF
--- a/internal/webhooks/monitoringconfig.go
+++ b/internal/webhooks/monitoringconfig.go
@@ -44,7 +44,8 @@ func SetupMonitoringConfigWebhookWithManager(mgr manager.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&everestv1alpha1.MonitoringConfig{}).
 		WithValidator(&MonitoringConfigValidator{
-			Client: mgr.GetClient(),
+			Client:    mgr.GetClient(),
+			apiReader: mgr.GetAPIReader(),
 		}).
 		Complete()
 }
@@ -54,6 +55,8 @@ func SetupMonitoringConfigWebhookWithManager(mgr manager.Manager) error {
 // MonitoringConfigValidator validates the MonitoringConfig resource.
 type MonitoringConfigValidator struct {
 	Client client.Client
+	// apiReader bypasses the cache and directly reads from the API server.
+	apiReader client.Reader
 }
 
 // ValidateCreate validates the creation of a DatabaseCluster.
@@ -85,10 +88,13 @@ func (v *MonitoringConfigValidator) validateMonitoringConfig(ctx context.Context
 	if secretName == "" {
 		return errors.New("missing secret name")
 	}
-	// ensure that the secret exists.
-	secret := corev1.Secret{}
 
-	if err := v.Client.Get(ctx, types.NamespacedName{
+	// Ensure that the secret exists.
+	// We read from the API server directly. This is because the webhook
+	// may be called before the cached client has had the chance to sync
+	// with the API server.
+	secret := corev1.Secret{}
+	if err := v.apiReader.Get(ctx, types.NamespacedName{
 		Name:      secretName,
 		Namespace: m.GetNamespace(),
 	}, &secret); err != nil {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-2217

MonitoringConfig validation webhook can sometimes fail to fetch Secret even though it exists. This generally occurs only after 1 MonitoringConfig already exists.

**Cause:**
* The validation webhook uses the default client to fetch the MonitoringConfig Secret. This client reads from the cache.
* The first MonitoringConfig always succeeds because caching has not yet started for Secrets, so the read it performed directly from the API server. However, when the second MonitoringConfig is created, it starts reading from the client cache.
* It is possible for the validation webhook to be called before the cache has had the time to sync with the Kube API server. As a result, it thinks that the Secret does not exist.

**Solution:**

Use `APIReader` for fetching the Secret -- this always bypasses the cache and reads directly from the API server.

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
