### PR TITLE
EVEREST-2233 Set ImagePullPolicy=IfNotPresent for upstream DB images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,14 +189,17 @@ test-e2e-data-importer-pxc: docker-build k3d-upload-image ## Run e2e/data-import
 	. ./tests/vars.sh && kubectl kuttl test --config ./tests/e2e/kuttl-data-importer.yaml --test pxc
 
 .PHONY: k3d-cluster-up
-k3d-cluster-up: ## Create a K8S cluster for testing
+k3d-cluster-up: ## Create a K8S cluster for testing.
 	k3d cluster create --config ./tests/k3d_config.yaml
 	k3d kubeconfig get everest-operator-test > ./tests/kubeconfig
 
 .PHONY: k3d-cluster-up
-k3d-cluster-down: ## Create a K8S cluster for testing
+k3d-cluster-down: ## Create a K8S cluster for testing.
 	k3d cluster delete --config ./tests/k3d_config.yaml
 	rm -f ./tests/kubeconfig || true
+
+.PHONY: k3d-cluster-reset
+k3d-cluster-reset: k3d-cluster-down k3d-cluster-up ## Recreate a K8S cluster for testing.
 
 .PHONY: k3d-upload-image
 k3d-upload-image:

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ ARCH=$(shell go env GOHOSTARCH)
 #.SHELLFLAGS = -ec
 
 .PHONY: all
-all: build
+all: help
 
 ##@ General
 

--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -152,6 +152,7 @@ func (p *applier) Engine() error {
 	if err != nil {
 		return err
 	}
+
 	pg.Spec.Extensions = pgv2.ExtensionsSpec{
 		Image:           image,
 		ImagePullPolicy: corev1.PullIfNotPresent,

--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -111,6 +111,7 @@ func (p *applier) Engine() error {
 	if !ok {
 		return fmt.Errorf("engine version %s not available", database.Spec.Engine.Version)
 	}
+
 	pg.Spec.Image = pgEngineVersion.ImagePath
 	pg.Spec.ImagePullPolicy = corev1.PullIfNotPresent
 	pgMajorVersionMatch := regexp.

--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -157,6 +157,7 @@ func (p *applier) Engine() error {
 		Image:           image,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 	}
+
 	return nil
 }
 

--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -114,6 +114,7 @@ func (p *applier) Engine() error {
 
 	pg.Spec.Image = pgEngineVersion.ImagePath
 	pg.Spec.ImagePullPolicy = corev1.PullIfNotPresent
+
 	pgMajorVersionMatch := regexp.
 		MustCompile(`^(\d+)`).
 		FindStringSubmatch(database.Spec.Engine.Version)

--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -112,6 +112,7 @@ func (p *applier) Engine() error {
 		return fmt.Errorf("engine version %s not available", database.Spec.Engine.Version)
 	}
 	pg.Spec.Image = pgEngineVersion.ImagePath
+	pg.Spec.ImagePullPolicy = corev1.PullIfNotPresent
 	pgMajorVersionMatch := regexp.
 		MustCompile(`^(\d+)`).
 		FindStringSubmatch(database.Spec.Engine.Version)
@@ -150,7 +151,8 @@ func (p *applier) Engine() error {
 		return err
 	}
 	pg.Spec.Extensions = pgv2.ExtensionsSpec{
-		Image: image,
+		Image:           image,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 	}
 	return nil
 }
@@ -329,10 +331,11 @@ func (p *applier) applyPMMCfg(monitoring *everestv1alpha1.MonitoringConfig) erro
 	ctx := p.ctx
 
 	pg.Spec.PMM = &pgv2.PMMSpec{
-		Enabled:   true,
-		Resources: common.GetPMMResources(pointer.Get(database.Spec.Monitoring), database.Spec.Engine.Size()),
-		Secret:    fmt.Sprintf("%s%s-pmm", consts.EverestSecretsPrefix, database.GetName()),
-		Image:     common.DefaultPMMClientImage,
+		Enabled:         true,
+		Resources:       common.GetPMMResources(pointer.Get(database.Spec.Monitoring), database.Spec.Engine.Size()),
+		Secret:          fmt.Sprintf("%s%s-pmm", consts.EverestSecretsPrefix, database.GetName()),
+		Image:           common.DefaultPMMClientImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 	}
 
 	if monitoring.Spec.PMM.Image != "" {

--- a/internal/controller/providers/psmdb/applier.go
+++ b/internal/controller/providers/psmdb/applier.go
@@ -113,6 +113,8 @@ func (p *applier) Engine() error {
 		return fmt.Errorf("engine version %s not available", database.Spec.Engine.Version)
 	}
 	psmdb.Spec.Image = engineVersion.ImagePath
+	psmdb.Spec.ImagePullPolicy = corev1.PullIfNotPresent
+
 	psmdb.Spec.Secrets = &psmdbv1.SecretsSpec{
 		Users:         database.Spec.Engine.UserSecretsName,
 		EncryptionKey: database.Name + encryptionKeySuffix,

--- a/internal/controller/providers/psmdb/applier.go
+++ b/internal/controller/providers/psmdb/applier.go
@@ -112,6 +112,7 @@ func (p *applier) Engine() error {
 	if !ok {
 		return fmt.Errorf("engine version %s not available", database.Spec.Engine.Version)
 	}
+
 	psmdb.Spec.Image = engineVersion.ImagePath
 	psmdb.Spec.ImagePullPolicy = corev1.PullIfNotPresent
 

--- a/internal/controller/providers/pxc/applier.go
+++ b/internal/controller/providers/pxc/applier.go
@@ -199,6 +199,7 @@ func (p *applier) Engine() error {
 		return fmt.Errorf("engine version %s not available", p.DB.Spec.Engine.Version)
 	}
 	pxc.Spec.PXC.Image = pxcEngineVersion.ImagePath
+	pxc.Spec.PXC.ImagePullPolicy = corev1.PullIfNotPresent
 
 	pxc.Spec.VolumeExpansionEnabled = true
 
@@ -507,6 +508,7 @@ func (p *applier) applyHAProxyCfg() error {
 		image = p.currentPerconaXtraDBClusterSpec.HAProxy.PodSpec.Image
 	}
 	haProxy.PodSpec.Image = image
+	haProxy.ImagePullPolicy = corev1.PullIfNotPresent
 
 	shouldUpdateRequests := shouldUpdateResourceRequests(p.DB.Status.Status)
 	if !p.DB.Spec.Proxy.Resources.CPU.IsZero() {

--- a/internal/controller/providers/pxc/applier.go
+++ b/internal/controller/providers/pxc/applier.go
@@ -198,6 +198,7 @@ func (p *applier) Engine() error {
 	if !ok {
 		return fmt.Errorf("engine version %s not available", p.DB.Spec.Engine.Version)
 	}
+
 	pxc.Spec.PXC.Image = pxcEngineVersion.ImagePath
 	pxc.Spec.PXC.ImagePullPolicy = corev1.PullIfNotPresent
 

--- a/tests/e2e/core/pg/10-assert.yaml
+++ b/tests/e2e/core/pg/10-assert.yaml
@@ -48,6 +48,7 @@ spec:
             resources:
               requests:
                 storage: 15G
+  imagePullPolicy: IfNotPresent
   instances:
   - dataVolumeClaimSpec:
       accessModes:

--- a/tests/e2e/core/pg/50-assert.yaml
+++ b/tests/e2e/core/pg/50-assert.yaml
@@ -39,6 +39,7 @@ spec:
             resources:
               requests:
                 storage: 15G
+  imagePullPolicy: IfNotPresent
   instances:
   - dataVolumeClaimSpec:
       accessModes:

--- a/tests/e2e/core/psmdb/10-assert.yaml
+++ b/tests/e2e/core/psmdb/10-assert.yaml
@@ -41,6 +41,7 @@ metadata:
     - percona.com/delete-psmdb-pods-in-order
     - percona.com/delete-psmdb-pvc
 spec:
+  imagePullPolicy: IfNotPresent
   multiCluster:
     enabled: false
   replsets:

--- a/tests/e2e/core/psmdb/50-assert.yaml
+++ b/tests/e2e/core/psmdb/50-assert.yaml
@@ -35,6 +35,7 @@ kind: PerconaServerMongoDB
 metadata:
   name: single-node
 spec:
+  imagePullPolicy: IfNotPresent
   multiCluster:
     enabled: false
   replsets:

--- a/tests/e2e/core/pxc/10-assert.yaml
+++ b/tests/e2e/core/pxc/10-assert.yaml
@@ -38,10 +38,12 @@ metadata:
     - delete-ssl
 spec:
   haproxy:
+    imagePullPolicy: IfNotPresent
     enabled: true
     exposePrimary: {}
     size: 3
   pxc:
+    imagePullPolicy: IfNotPresent
     configuration: |
       [mysqld]
       wsrep_provider_options="debug=1;gcache.size=1G"

--- a/tests/e2e/core/pxc/50-assert.yaml
+++ b/tests/e2e/core/pxc/50-assert.yaml
@@ -33,9 +33,11 @@ metadata:
 spec:
   haproxy:
     enabled: true
+    imagePullPolicy: IfNotPresent
     exposePrimary: {}
     size: 1
   pxc:
+    imagePullPolicy: IfNotPresent
     configuration: |
       [mysqld]
       wsrep_provider_options="debug=1;gcache.size=1G"

--- a/tests/integration/core/pg/10-assert.yaml
+++ b/tests/integration/core/pg/10-assert.yaml
@@ -95,6 +95,8 @@ spec:
   extensions:
     builtin: {}
     storage: {}
+    imagePullPolicy: IfNotPresent
+  imagePullPolicy: IfNotPresent
   instances:
   - dataVolumeClaimSpec:
       accessModes:

--- a/tests/integration/core/pg/40-assert.yaml
+++ b/tests/integration/core/pg/40-assert.yaml
@@ -95,6 +95,8 @@ spec:
   extensions:
     builtin: {}
     storage: {}
+    imagePullPolicy: IfNotPresent
+  imagePullPolicy: IfNotPresent
   instances:
     - dataVolumeClaimSpec:
         accessModes:

--- a/tests/integration/core/psmdb/10-assert.yaml
+++ b/tests/integration/core/psmdb/10-assert.yaml
@@ -78,6 +78,7 @@ kind: PerconaServerMongoDB
 metadata:
   name: test-psmdb-cluster
 spec:
+  imagePullPolicy: IfNotPresent
   backup:
     configuration:
       backupOptions:

--- a/tests/integration/core/psmdb/40-assert.yaml
+++ b/tests/integration/core/psmdb/40-assert.yaml
@@ -78,6 +78,7 @@ kind: PerconaServerMongoDB
 metadata:
   name: test-psmdb-cluster
 spec:
+  imagePullPolicy: IfNotPresent
   backup:
     configuration:
       backupOptions:

--- a/tests/integration/core/pxc/10-assert.yaml
+++ b/tests/integration/core/pxc/10-assert.yaml
@@ -147,6 +147,7 @@ spec:
             http-request use-service prometheus-exporter if { path /metrics }
     enabled: true
     envVarsSecret: haproxy-env-secret
+    imagePullPolicy: IfNotPresent
     exposePrimary: {}
     lifecycle: {}
     livenessProbes:
@@ -200,6 +201,7 @@ spec:
       maxUnavailable: 1
     readinessProbes:
       timeoutSeconds: 450
+    imagePullPolicy: IfNotPresent
     resources:
       limits:
         cpu: "1"

--- a/tests/integration/core/pxc/40-assert.yaml
+++ b/tests/integration/core/pxc/40-assert.yaml
@@ -89,6 +89,7 @@ spec:
       resources: {}
       storageName: ""
   haproxy:
+    imagePullPolicy: IfNotPresent
     configuration: |2
 
           global
@@ -171,6 +172,7 @@ spec:
         memory: 1G
     sidecarResources: {}
   pxc:
+    imagePullPolicy: IfNotPresent
     configuration: "[mysqld]\nbinlog_cache_size = 131072\nbinlog_expire_logs_seconds
       = 604800\nbinlog_format = ROW\nbinlog_stmt_cache_size = 131072\nglobal-connection-memory-limit
       = 18446744073709551615\nglobal-connection-memory-tracking = false\ninnodb_adaptive_hash_index

--- a/tests/integration/features/monitoringconfig_pg/10-assert.yaml
+++ b/tests/integration/features/monitoringconfig_pg/10-assert.yaml
@@ -96,6 +96,7 @@ spec:
     serverHost: localhost-mc-pg
     secret: everest-secrets-pg-mc-pmm
     image: percona/pmm-client:latest
+    imagePullPolicy: IfNotPresent
     querySource: pgstatmonitor
     resources:
       requests:

--- a/tests/integration/features/monitoringconfig_pg/50-assert.yaml
+++ b/tests/integration/features/monitoringconfig_pg/50-assert.yaml
@@ -94,6 +94,7 @@ spec:
     serverHost: localhost-mc-pg-updated
     secret: everest-secrets-pg-mc-pmm
     image: percona/pmm-client:updated
+    imagePullPolicy: IfNotPresent
     querySource: pgstatmonitor
     resources:
       requests:


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-2233

*Short explanation of the problem.*
Upstream DB CRs in most cases have `imagePullPolicy=Always` even for DB engine images. That leads to the following problems:

1. DB cluster restoration after some node failure takes more time because the images need to be re-fetched on each Pod creation.
2. Big companies/users that have a common external IP may face with "DockerHub Rate Limits" issues.
2.1. Image download speed  from DockerHub is not stable and may vary in time -> increases DB cluster restoration time after Node failure.
4. Our tests that create/destroy DB clusters massively are unstable due to unpredictable Pod creation time and "Rate limit" problems

**Solution:**
The images are tagged and  stable so there is no need to re-fetch them each time (nothing new will appear in them). So it is safe to set `imagePullPolicy=IfNotPresent`. 
That allows to decrease DB cluster restoration time and decreasing the chance to hit "DockerHub Rate Limit". In addition in our tests we can pre-upload images into K8S to stabilise Pods creations.
