### PR TITLE
EVEREST-2264 Handle annotations removal

### DIFF
--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -181,6 +181,7 @@ func (p *applier) Proxy() error {
 		pg.Spec.Proxy.PGBouncer.ServiceExpose = &pgv2.ServiceExpose{
 			Type: string(corev1.ServiceTypeClusterIP),
 		}
+		pg.Spec.Proxy.PGBouncer.ServiceExpose.Annotations = map[string]string{}
 	case everestv1alpha1.ExposeTypeExternal:
 		pg.Spec.Proxy.PGBouncer.ServiceExpose = &pgv2.ServiceExpose{
 			Type:                     string(corev1.ServiceTypeLoadBalancer),

--- a/internal/controller/providers/psmdb/applier.go
+++ b/internal/controller/providers/psmdb/applier.go
@@ -262,6 +262,7 @@ func (p *applier) exposeShardedCluster(expose *psmdbv1.MongosExpose) error {
 	switch database.Spec.Proxy.Expose.Type {
 	case everestv1alpha1.ExposeTypeInternal:
 		expose.ExposeType = corev1.ServiceTypeClusterIP
+		expose.ServiceAnnotations = map[string]string{}
 	case everestv1alpha1.ExposeTypeExternal:
 		expose.ExposeType = corev1.ServiceTypeLoadBalancer
 		expose.LoadBalancerSourceRanges = database.Spec.Proxy.Expose.IPSourceRangesStringArray()
@@ -282,8 +283,9 @@ func (p *applier) exposeDefaultReplSet(expose *psmdbv1.ExposeTogglable) error {
 	database := p.DB
 	switch database.Spec.Proxy.Expose.Type {
 	case everestv1alpha1.ExposeTypeInternal:
-		expose.Enabled = false
+		expose.Enabled = true
 		expose.ExposeType = corev1.ServiceTypeClusterIP
+		expose.ServiceAnnotations = map[string]string{}
 	case everestv1alpha1.ExposeTypeExternal:
 		expose.Enabled = true
 		expose.ExposeType = corev1.ServiceTypeLoadBalancer

--- a/internal/controller/providers/pxc/applier.go
+++ b/internal/controller/providers/pxc/applier.go
@@ -452,7 +452,13 @@ func (p *applier) applyHAProxyCfg() error {
 
 	switch p.DB.Spec.Proxy.Expose.Type {
 	case everestv1alpha1.ExposeTypeInternal:
-		// No need to set anything, defaults are fine.
+		expose := pxcv1.ServiceExpose{
+			Enabled:     true,
+			Type:        corev1.ServiceTypeClusterIP,
+			Annotations: map[string]string{},
+		}
+		haProxy.ExposePrimary = expose
+		haProxy.ExposeReplicas = &pxcv1.ReplicasServiceExpose{ServiceExpose: expose}
 	case everestv1alpha1.ExposeTypeExternal:
 		annotations, err := common.GetAnnotations(p.ctx, p.C, p.DB)
 		if err != nil {
@@ -560,7 +566,12 @@ func (p *applier) applyProxySQLCfg() error {
 
 	switch p.DB.Spec.Proxy.Expose.Type {
 	case everestv1alpha1.ExposeTypeInternal:
-		// No need to set anything, defaults are fine.
+		expose := pxcv1.ServiceExpose{
+			Enabled:     true,
+			Type:        corev1.ServiceTypeClusterIP,
+			Annotations: map[string]string{},
+		}
+		proxySQL.Expose = expose
 	case everestv1alpha1.ExposeTypeExternal:
 		annotations, err := common.GetAnnotations(p.ctx, p.C, p.DB)
 		if err != nil {

--- a/tests/e2e/core/psmdb/10-assert.yaml
+++ b/tests/e2e/core/psmdb/10-assert.yaml
@@ -48,7 +48,7 @@ spec:
        operationProfiling:
           mode: slowOp
       expose:
-        enabled: false
+        enabled: true
       name: rs0
       resources:
         limits:

--- a/tests/e2e/core/psmdb/30-assert.yaml
+++ b/tests/e2e/core/psmdb/30-assert.yaml
@@ -46,7 +46,7 @@ spec:
        operationProfiling:
           mode: off
       expose:
-        enabled: false
+        enabled: true
       name: rs0
       resources:
         limits:

--- a/tests/e2e/core/psmdb/50-assert.yaml
+++ b/tests/e2e/core/psmdb/50-assert.yaml
@@ -42,7 +42,7 @@ spec:
        operationProfiling:
           mode: slowOp
       expose:
-        enabled: false
+        enabled: true
       name: rs0
       resources:
         limits:

--- a/tests/e2e/core/psmdb/60-assert.yaml
+++ b/tests/e2e/core/psmdb/60-assert.yaml
@@ -39,7 +39,7 @@ spec:
        operationProfiling:
           mode: slowOp
       expose:
-        enabled: false
+        enabled: true
       name: rs0
       resources:
         limits:

--- a/tests/e2e/db-upgrade/psmdb/10-assert.yaml
+++ b/tests/e2e/db-upgrade/psmdb/10-assert.yaml
@@ -48,7 +48,7 @@ spec:
        operationProfiling:
           mode: slowOp
       expose:
-        enabled: false
+        enabled: true
       name: rs0
       resources:
         limits:

--- a/tests/e2e/db-upgrade/psmdb/20-assert.yaml
+++ b/tests/e2e/db-upgrade/psmdb/20-assert.yaml
@@ -46,7 +46,7 @@ spec:
        operationProfiling:
           mode: slowOp
       expose:
-        enabled: false
+        enabled: true
       name: rs0
       resources:
         limits:

--- a/tests/e2e/db-upgrade/psmdb/30-assert.yaml
+++ b/tests/e2e/db-upgrade/psmdb/30-assert.yaml
@@ -46,7 +46,7 @@ spec:
        operationProfiling:
           mode: slowOp
       expose:
-        enabled: false
+        enabled: true
       name: rs0
       resources:
         limits:

--- a/tests/e2e/db-upgrade/psmdb/40-assert.yaml
+++ b/tests/e2e/db-upgrade/psmdb/40-assert.yaml
@@ -46,7 +46,7 @@ spec:
        operationProfiling:
           mode: slowOp
       expose:
-        enabled: false
+        enabled: true
       name: rs0
       resources:
         limits:

--- a/tests/e2e/db-upgrade/psmdb/50-assert.yaml
+++ b/tests/e2e/db-upgrade/psmdb/50-assert.yaml
@@ -46,7 +46,7 @@ spec:
        operationProfiling:
           mode: slowOp
       expose:
-        enabled: false
+        enabled: true
       name: rs0
       resources:
         limits:

--- a/tests/e2e/operator-upgrade/psmdb/10-assert.yaml
+++ b/tests/e2e/operator-upgrade/psmdb/10-assert.yaml
@@ -31,7 +31,7 @@ metadata:
 spec:
   replsets:
     - expose:
-        enabled: false
+        enabled: true
       name: rs0
       size:        3
       volumeSpec:

--- a/tests/e2e/operator-upgrade/psmdb/20-assert.yaml
+++ b/tests/e2e/operator-upgrade/psmdb/20-assert.yaml
@@ -44,7 +44,7 @@ metadata:
 spec:
   replsets:
     - expose:
-        enabled: false
+        enabled: true
       name: rs0
       size:        3
       volumeSpec:

--- a/tests/e2e/operator-upgrade/psmdb/30-assert.yaml
+++ b/tests/e2e/operator-upgrade/psmdb/30-assert.yaml
@@ -29,7 +29,7 @@ metadata:
 spec:
   replsets:
     - expose:
-        enabled: false
+        enabled: true
       name: rs0
       size:        3
       volumeSpec:

--- a/tests/e2e/operator-upgrade/psmdb/31-assert.yaml
+++ b/tests/e2e/operator-upgrade/psmdb/31-assert.yaml
@@ -31,7 +31,7 @@ metadata:
 spec:
   replsets:
     - expose:
-        enabled: false
+        enabled: true
       name: rs0
       size:        3
       volumeSpec:

--- a/tests/integration/core/psmdb/10-assert.yaml
+++ b/tests/integration/core/psmdb/10-assert.yaml
@@ -98,7 +98,7 @@ spec:
       resources: {}
       size: 0
     expose:
-      enabled: false
+      enabled: true
       type: ClusterIP
     name: rs0
     nonvoting:

--- a/tests/integration/core/psmdb/11-assert.yaml
+++ b/tests/integration/core/psmdb/11-assert.yaml
@@ -86,7 +86,7 @@ spec:
         resources: {}
         size: 0
       expose:
-        enabled: false
+        enabled: true
         type: ClusterIP
       name: rs0
       nonvoting:

--- a/tests/integration/core/psmdb/20-assert.yaml
+++ b/tests/integration/core/psmdb/20-assert.yaml
@@ -95,7 +95,7 @@ spec:
         resources: {}
         size: 0
       expose:
-        enabled: false
+        enabled: true
         type: ClusterIP
       name: rs0
       nonvoting:

--- a/tests/integration/core/psmdb/40-assert.yaml
+++ b/tests/integration/core/psmdb/40-assert.yaml
@@ -98,7 +98,7 @@ spec:
         resources: {}
         size: 0
       expose:
-        enabled: false
+        enabled: true
         type: ClusterIP
       name: rs0
       nonvoting:

--- a/tests/integration/core/psmdb/41-assert.yaml
+++ b/tests/integration/core/psmdb/41-assert.yaml
@@ -86,7 +86,7 @@ spec:
         resources: {}
         size: 0
       expose:
-        enabled: false
+        enabled: true
         type: ClusterIP
       name: rs0
       nonvoting:


### PR DESCRIPTION
**Handle annotations removal**
---
**Problem:**
EVEREST-2264

Everest wasn't handling properly the case of switching from `LoadBalancer` expose type to `ClusterIP`. 
However as it turned out, the annotations can be effectively removed only for `pg`, but the `pxc` and `psmdb` operators do not allow to delete the annotations by design (there was some reason for it which the Cloud team can't remember so far). 

As discussed with the Cloud team, there should be no harm in keeping the annotations when we change to the expose type to ClusterIP, they just will be ignored. So looks like we need to accept it as a limitation in Everest until it's fixed in the upstream. 

psmdb ticket https://perconadev.atlassian.net/browse/K8SPSMDB-1441
pxc ticket https://perconadev.atlassian.net/browse/K8SPXC-1709 

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
