### PR TITLE
EVEREST-2268 Handle existing providers annotations

### DIFF
--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -78,7 +78,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-08-21T07:02:37Z"
+    createdAt: "2025-09-03T08:37:42Z"
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: everest-operator.v0.0.0
@@ -145,6 +145,7 @@ spec:
           resources:
           - namespaces
           - persistentvolumeclaims
+          - services
           verbs:
           - get
           - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - namespaces
   - persistentvolumeclaims
+  - services
   verbs:
   - get
   - list

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -8719,6 +8719,7 @@ rules:
   resources:
   - namespaces
   - persistentvolumeclaims
+  - services
   verbs:
   - get
   - list

--- a/internal/consts/annotations.go
+++ b/internal/consts/annotations.go
@@ -30,4 +30,9 @@ const (
 	ManagedByDataImportAnnotation = EverestAnnotationPrefix + "managed-by-data-import"
 	// ManagedByDataImportAnnotationValueTrue is the value for the ManagedByDataImportAnnotation to indicate that the resource is managed by data import.
 	ManagedByDataImportAnnotationValueTrue = "true"
+	// DefaultEverestExposeServiceAnnotationsKey is the annotation key which is used by default in all everest-managed exposure services
+	// to be able to cleanup the annotations list since the upstream does not allow to delete all annotations
+	DefaultEverestExposeServiceAnnotationsKey = "everest.percona.com/custom-annotations"
+	// DefaultEverestExposeServiceAnnotationsValue is the value used for DefaultEverestExposeServiceAnnotationsKey
+	DefaultEverestExposeServiceAnnotationsValue = "true"
 )

--- a/internal/consts/annotations.go
+++ b/internal/consts/annotations.go
@@ -31,8 +31,8 @@ const (
 	// ManagedByDataImportAnnotationValueTrue is the value for the ManagedByDataImportAnnotation to indicate that the resource is managed by data import.
 	ManagedByDataImportAnnotationValueTrue = "true"
 	// DefaultEverestExposeServiceAnnotationsKey is the annotation key which is used by default in all everest-managed exposure services
-	// to be able to cleanup the annotations list since the upstream does not allow to delete all annotations
+	// to be able to cleanup the annotations list since the upstream does not allow to delete all annotations.
 	DefaultEverestExposeServiceAnnotationsKey = "everest.percona.com/custom-annotations"
-	// DefaultEverestExposeServiceAnnotationsValue is the value used for DefaultEverestExposeServiceAnnotationsKey
+	// DefaultEverestExposeServiceAnnotationsValue is the value used for DefaultEverestExposeServiceAnnotationsKey.
 	DefaultEverestExposeServiceAnnotationsValue = "true"
 )

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -73,22 +73,22 @@ const (
 
 	// ExposureSvcLabel is a common label used in exposure services to store the related cluster.
 	ExposureSvcLabel = "app.kubernetes.io/instance"
-	// ComponentLabel is a common label used to specify the component this resource is related to
+	// ComponentLabel is a common label used to specify the component this resource is related to.
 	ComponentLabel = "app.kubernetes.io/component"
 
-	// HAProxyComponentLabelValue is the ComponentLabel value specific for HAProxy
+	// HAProxyComponentLabelValue is the ComponentLabel value specific for HAProxy.
 	HAProxyComponentLabelValue = "haproxy"
 
-	// ProxySQLComponentLabelValue is the ComponentLabel value specific for ProxySQL
+	// ProxySQLComponentLabelValue is the ComponentLabel value specific for ProxySQL.
 	ProxySQLComponentLabelValue = "proxysql"
 
-	// PGBouncerComponentLabelValue is the ComponentLabel value specific for PGBouncer
+	// PGBouncerComponentLabelValue is the ComponentLabel value specific for PGBouncer.
 	PGBouncerComponentLabelValue = "pgbouncer"
 
-	// PSMDBReplicasetComponentLabelValue is the ComponentLabel value specific for psmdb non-sharded clusters
+	// PSMDBReplicasetComponentLabelValue is the ComponentLabel value specific for psmdb non-sharded clusters.
 	PSMDBReplicasetComponentLabelValue = "external-service"
 
-	// PSMDBShardedComponentLabelValue is the ComponentLabel value specific for psmdb sharded clusters
+	// PSMDBShardedComponentLabelValue is the ComponentLabel value specific for psmdb sharded clusters.
 	PSMDBShardedComponentLabelValue = "mongos"
 
 	// EverestSecretsPrefix is the prefix for secrets created by Everest.

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -71,6 +71,26 @@ const (
 	// LabelKubernetesManagedBy is a common label that indicates the resource is managed by a specific operator.
 	LabelKubernetesManagedBy = "app.kubernetes.io/managed-by"
 
+	// ExposureSvcLabel is a common label used in exposure services to store the related cluster.
+	ExposureSvcLabel = "app.kubernetes.io/instance"
+	// ComponentLabel is a common label used to specify the component this resource is related to
+	ComponentLabel = "app.kubernetes.io/component"
+
+	// HAProxyComponentLabelValue is the ComponentLabel value specific for HAProxy
+	HAProxyComponentLabelValue = "haproxy"
+
+	// ProxySQLComponentLabelValue is the ComponentLabel value specific for ProxySQL
+	ProxySQLComponentLabelValue = "proxysql"
+
+	// PGBouncerComponentLabelValue is the ComponentLabel value specific for PGBouncer
+	PGBouncerComponentLabelValue = "pgbouncer"
+
+	// PSMDBReplicasetComponentLabelValue is the ComponentLabel value specific for psmdb non-sharded clusters
+	PSMDBReplicasetComponentLabelValue = "external-service"
+
+	// PSMDBShardedComponentLabelValue is the ComponentLabel value specific for psmdb sharded clusters
+	PSMDBShardedComponentLabelValue = "mongos"
+
 	// EverestSecretsPrefix is the prefix for secrets created by Everest.
 	EverestSecretsPrefix = "everest-secrets-"
 )

--- a/internal/controller/common/exposure_annotations.go
+++ b/internal/controller/common/exposure_annotations.go
@@ -1,0 +1,120 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	"github.com/percona/everest-operator/internal/consts"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var errNoSvcFound = errors.New("no expose service found")
+
+// ReconcileExposureAnnotations returns the annotations to apply to the upstream cluster, the list of annotations keys to ignore to avoid overriding and an error
+func ReconcileExposureAnnotations(ctx context.Context, c client.Client, db *everestv1alpha1.DatabaseCluster, upstreamAnnotations map[string]string, componentName string) (desiredUpstreamAnnotations map[string]string, ignore []string, err error) {
+	serviceAnnotations, err := getExposeServiceAnnotations(ctx, c, db, componentName)
+
+	if err != nil {
+		// if there is no service available yet, we shouldn't populate the upstream annotations & ignore
+		if errors.Is(err, errNoSvcFound) {
+			return map[string]string{}, []string{}, nil
+		}
+		return nil, nil, err
+	}
+	everestAnnotations, err := getAnnotations(ctx, c, db)
+	if err != nil {
+		return nil, nil, err
+	}
+	desiredUpstreamAnnotations = addDefaultAnnotation(everestAnnotations)
+
+	return desiredUpstreamAnnotations, getUniqueKeys(serviceAnnotations, upstreamAnnotations), nil
+}
+
+// getAnnotations returns annotations from the LoadBalancerConfig used in the given DB.
+func getAnnotations(
+	ctx context.Context,
+	c client.Client,
+	database *everestv1alpha1.DatabaseCluster,
+) (map[string]string, error) {
+	lbc, err := GetLoadBalancerConfig(ctx, c, database)
+	if err != nil {
+		if errors.Is(err, ErrEmptyLbc) {
+			return map[string]string{}, nil
+		}
+
+		return nil, err
+	}
+
+	return lbc.Spec.Annotations, nil
+}
+
+// getExposeServiceAnnotations returns the annotations of the expose service
+func getExposeServiceAnnotations(ctx context.Context, c client.Client, db *everestv1alpha1.DatabaseCluster, componentName string) (map[string]string, error) {
+	svcs := &corev1.ServiceList{}
+	err := c.List(ctx, svcs, client.InNamespace(db.GetNamespace()), client.MatchingLabels{
+		consts.ExposureSvcLabel: db.GetName(),
+		consts.ComponentLabel:   componentName,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(svcs.Items) == 0 {
+		return nil, errNoSvcFound
+	}
+
+	var emptyMap = make(map[string]string)
+	exposeType := db.Spec.Proxy.Expose.Type
+
+	switch exposeType {
+	// for internal exposure type we don't care about the annotations
+	case everestv1alpha1.ExposeTypeInternal:
+		return emptyMap, nil
+	case everestv1alpha1.ExposeTypeExternal:
+		result := make(map[string]string)
+		// pxc has two services (primary and replicas), non-sharded psmdb has as many as the number of nodes,
+		// so we need to iterate through them and collect all the existing annotations keys
+		for _, svc := range svcs.Items {
+			// if the service type is already LB, collect the existing annotations
+			if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+				mergeMaps(result, svc.Annotations)
+			}
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("invalid expose type: %s", exposeType)
+	}
+
+	return emptyMap, nil
+}
+
+// everest always adds the default annotation to the list to be able to delete all custom annotations
+// since the upstream operator does not support it
+func addDefaultAnnotation(annotations map[string]string) map[string]string {
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	if _, ok := annotations[consts.DefaultEverestExposeServiceAnnotationsKey]; !ok {
+		annotations[consts.DefaultEverestExposeServiceAnnotationsKey] = consts.DefaultEverestExposeServiceAnnotationsValue
+	}
+	return annotations
+}
+
+// returns the keys that appears only in minuend
+func getUniqueKeys(minuend, subtrahend map[string]string) []string {
+	keys := make([]string, 0)
+	for k := range minuend {
+		if _, found := subtrahend[k]; !found {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+func mergeMaps(dst, src map[string]string) {
+	for k, v := range src {
+		dst[k] = v
+	}
+}

--- a/internal/controller/common/exposure_annotations.go
+++ b/internal/controller/common/exposure_annotations.go
@@ -5,10 +5,11 @@ import (
 	"errors"
 	"fmt"
 
-	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
-	"github.com/percona/everest-operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	"github.com/percona/everest-operator/internal/consts"
 )
 
 var errNoSvcFound = errors.New("no expose service found")
@@ -16,7 +17,6 @@ var errNoSvcFound = errors.New("no expose service found")
 // ReconcileExposureAnnotations returns the annotations to apply to the upstream cluster, the list of annotations keys to ignore to avoid overriding and an error
 func ReconcileExposureAnnotations(ctx context.Context, c client.Client, db *everestv1alpha1.DatabaseCluster, upstreamAnnotations map[string]string, componentName string) (desiredUpstreamAnnotations map[string]string, ignore []string, err error) {
 	serviceAnnotations, err := getExposeServiceAnnotations(ctx, c, db, componentName)
-
 	if err != nil {
 		// if there is no service available yet, we shouldn't populate the upstream annotations & ignore
 		if errors.Is(err, errNoSvcFound) {
@@ -65,7 +65,7 @@ func getExposeServiceAnnotations(ctx context.Context, c client.Client, db *evere
 		return nil, errNoSvcFound
 	}
 
-	var emptyMap = make(map[string]string)
+	emptyMap := make(map[string]string)
 	exposeType := db.Spec.Proxy.Expose.Type
 
 	switch exposeType {

--- a/internal/controller/common/exposure_annotations.go
+++ b/internal/controller/common/exposure_annotations.go
@@ -1,4 +1,19 @@
-package common
+// everest-operator
+// Copyright (C) 2022 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common //nolint:revive,nolintlint
 
 import (
 	"context"
@@ -14,8 +29,18 @@ import (
 
 var errNoSvcFound = errors.New("no expose service found")
 
-// ReconcileExposureAnnotations returns the annotations to apply to the upstream cluster, the list of annotations keys to ignore to avoid overriding and an error
-func ReconcileExposureAnnotations(ctx context.Context, c client.Client, db *everestv1alpha1.DatabaseCluster, upstreamAnnotations map[string]string, componentName string) (desiredUpstreamAnnotations map[string]string, ignore []string, err error) {
+// ReconcileExposureAnnotations returns the annotations to apply to the upstream cluster, the list of annotations keys to ignore to avoid overriding and an error.
+func ReconcileExposureAnnotations( //nolint:nonamedreturns
+	ctx context.Context,
+	c client.Client,
+	db *everestv1alpha1.DatabaseCluster,
+	upstreamAnnotations map[string]string,
+	componentName string,
+) (
+	desiredUpstreamAnnotations map[string]string,
+	ignore []string,
+	err error,
+) {
 	serviceAnnotations, err := getExposeServiceAnnotations(ctx, c, db, componentName)
 	if err != nil {
 		// if there is no service available yet, we shouldn't populate the upstream annotations & ignore
@@ -51,7 +76,7 @@ func getAnnotations(
 	return lbc.Spec.Annotations, nil
 }
 
-// getExposeServiceAnnotations returns the annotations of the expose service
+// getExposeServiceAnnotations returns the annotations of the expose service.
 func getExposeServiceAnnotations(ctx context.Context, c client.Client, db *everestv1alpha1.DatabaseCluster, componentName string) (map[string]string, error) {
 	svcs := &corev1.ServiceList{}
 	err := c.List(ctx, svcs, client.InNamespace(db.GetNamespace()), client.MatchingLabels{
@@ -86,12 +111,10 @@ func getExposeServiceAnnotations(ctx context.Context, c client.Client, db *evere
 	default:
 		return nil, fmt.Errorf("invalid expose type: %s", exposeType)
 	}
-
-	return emptyMap, nil
 }
 
 // everest always adds the default annotation to the list to be able to delete all custom annotations
-// since the upstream operator does not support it
+// since the upstream operator does not support it.
 func addDefaultAnnotation(annotations map[string]string) map[string]string {
 	if annotations == nil {
 		annotations = make(map[string]string)
@@ -102,7 +125,7 @@ func addDefaultAnnotation(annotations map[string]string) map[string]string {
 	return annotations
 }
 
-// returns the keys that appears only in minuend
+// returns the keys that appears only in minuend.
 func getUniqueKeys(minuend, subtrahend map[string]string) []string {
 	keys := make([]string, 0)
 	for k := range minuend {

--- a/internal/controller/common/exposure_annotations_test.go
+++ b/internal/controller/common/exposure_annotations_test.go
@@ -1,0 +1,323 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	"github.com/percona/everest-operator/internal/consts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcileExposureAnnotations(t *testing.T) {
+	type testCase struct {
+		name                        string
+		lbcs                        []client.Object
+		services                    []client.ObjectList
+		db                          *everestv1alpha1.DatabaseCluster
+		existingUpstreamAnnotations map[string]string
+		err                         error
+		desiredAnnotations          map[string]string
+		desiredIgnore               []string
+	}
+	ctx := context.Background()
+	namespace := "test"
+	dbName := "db"
+
+	cases := []testCase{
+		{
+			name:                        "LB service exists and has annotations; exposed DB with no lbc",
+			lbcs:                        []client.Object{},
+			services:                    servicesList(t, dbName, namespace, map[string]string{"from/svc": "value-from-svc"}, corev1.ServiceTypeLoadBalancer),
+			db:                          db(t, dbName, namespace, "", everestv1alpha1.ExposeTypeExternal),
+			existingUpstreamAnnotations: map[string]string{},
+			err:                         nil,
+			desiredIgnore:               []string{"from/svc"},
+			desiredAnnotations: map[string]string{
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+		},
+		{
+			name:                        "LB service exists and has no annotations; exposed DB with no lbc",
+			lbcs:                        []client.Object{},
+			services:                    servicesList(t, dbName, namespace, map[string]string{}, corev1.ServiceTypeLoadBalancer),
+			db:                          db(t, dbName, namespace, "", everestv1alpha1.ExposeTypeExternal),
+			existingUpstreamAnnotations: map[string]string{},
+			err:                         nil,
+			desiredIgnore:               []string{},
+			desiredAnnotations: map[string]string{
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+		},
+		{
+			name:                        "LB service exists and has no annotations; exposed DB with lbc",
+			lbcs:                        lbcs(t, "lbc", map[string]string{"from/lbc": "value-from-lbc"}),
+			services:                    servicesList(t, dbName, namespace, map[string]string{}, corev1.ServiceTypeLoadBalancer),
+			db:                          db(t, dbName, namespace, "lbc", everestv1alpha1.ExposeTypeExternal),
+			existingUpstreamAnnotations: map[string]string{},
+			err:                         nil,
+			desiredIgnore:               []string{},
+			desiredAnnotations: map[string]string{
+				"from/lbc": "value-from-lbc",
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+		},
+		{
+			name:                        "LB service exists and has annotations; exposed DB with lbc",
+			lbcs:                        lbcs(t, "lbc", map[string]string{"from/lbc": "value-from-lbc"}),
+			services:                    servicesList(t, dbName, namespace, map[string]string{"from/svc": "value-from-svc"}, corev1.ServiceTypeLoadBalancer),
+			db:                          db(t, dbName, namespace, "lbc", everestv1alpha1.ExposeTypeExternal),
+			existingUpstreamAnnotations: map[string]string{},
+			err:                         nil,
+			desiredIgnore:               []string{"from/svc"},
+			desiredAnnotations: map[string]string{
+				"from/lbc": "value-from-lbc",
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+		},
+		{
+			name:                        "expose service is not LB; not exposed DB with lbc",
+			lbcs:                        lbcs(t, "lbc", map[string]string{"from/lbc": "value-from-lbc"}),
+			services:                    servicesList(t, dbName, namespace, map[string]string{"from/svc": "value-from-svc"}, corev1.ServiceTypeClusterIP),
+			db:                          db(t, dbName, namespace, "lbc", everestv1alpha1.ExposeTypeInternal),
+			existingUpstreamAnnotations: map[string]string{},
+			err:                         nil,
+			desiredIgnore:               []string{},
+			desiredAnnotations: map[string]string{
+				"from/lbc": "value-from-lbc",
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+		},
+		{
+			name:                        "expose service is not LB; not exposed DB no lbc",
+			lbcs:                        []client.Object{},
+			services:                    servicesList(t, dbName, namespace, map[string]string{"from/svc": "value-from-svc"}, corev1.ServiceTypeClusterIP),
+			db:                          db(t, dbName, namespace, "", everestv1alpha1.ExposeTypeInternal),
+			existingUpstreamAnnotations: map[string]string{},
+			err:                         nil,
+			desiredIgnore:               []string{},
+			desiredAnnotations: map[string]string{
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+		},
+		{
+			name:                        "No expose svc available",
+			lbcs:                        []client.Object{},
+			services:                    []client.ObjectList{},
+			db:                          db(t, dbName, namespace, "", everestv1alpha1.ExposeTypeInternal),
+			existingUpstreamAnnotations: map[string]string{},
+			err:                         nil,
+			desiredIgnore:               []string{},
+			desiredAnnotations:          map[string]string{},
+		},
+		{
+			name: "cloud provider adds it's own annotation",
+			lbcs: lbcs(t, "lbc", map[string]string{"from/lbc": "value-from-lbc"}),
+			services: servicesList(t, dbName, namespace, map[string]string{
+				"from/svc":         "value-from-svc", // annotation added by cloud provider
+				"last-config-hash": "some-hash",
+				"from/lbc":         "value-from-lbc",
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			}, corev1.ServiceTypeLoadBalancer),
+			db: db(t, dbName, namespace, "lbc", everestv1alpha1.ExposeTypeExternal),
+			existingUpstreamAnnotations: map[string]string{
+				"last-config-hash": "some-hash", // annotation added by upstream operator
+				"from/lbc":         "value-from-lbc",
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+			err: nil,
+			desiredIgnore: []string{
+				"from/svc", // ignore the cloud provider added annotation
+			},
+			// expect only the everest-defined annotations
+			desiredAnnotations: map[string]string{
+				"from/lbc": "value-from-lbc",
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+		},
+		{
+			name:                        "Expose svc is clusterIP, db defines LoadBalancer",
+			lbcs:                        []client.Object{},
+			services:                    servicesList(t, dbName, namespace, map[string]string{}, corev1.ServiceTypeClusterIP),
+			db:                          db(t, dbName, namespace, "", everestv1alpha1.ExposeTypeExternal),
+			existingUpstreamAnnotations: map[string]string{},
+			err:                         nil,
+			desiredIgnore:               []string{},
+			desiredAnnotations: map[string]string{
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+		},
+		{
+			name: "Expose svc is clusterIP with the cloud provider's defined annotations; db defines LoadBalancer",
+			lbcs: []client.Object{},
+			services: servicesList(t, dbName, namespace, map[string]string{
+				"from/svc": "value-from-svc", // cloud provider's added annotation
+			}, corev1.ServiceTypeClusterIP),
+			db:                          db(t, dbName, namespace, "", everestv1alpha1.ExposeTypeExternal),
+			existingUpstreamAnnotations: map[string]string{},
+			err:                         nil,
+			desiredIgnore:               []string{}, // the cloud provider's added annotations are not ignored since the svc type is not LB
+			desiredAnnotations: map[string]string{
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+		},
+		{
+			name:                        "Two LB svcs (pxc-like experience) with different cloud provider's defined annotations",
+			lbcs:                        []client.Object{},
+			services:                    servicesListTwoSvcs(t, dbName, namespace, map[string]string{"a1": "val1"}, map[string]string{"a2": "val2"}, corev1.ServiceTypeLoadBalancer, corev1.ServiceTypeLoadBalancer),
+			db:                          db(t, dbName, namespace, "", everestv1alpha1.ExposeTypeExternal),
+			existingUpstreamAnnotations: map[string]string{},
+			err:                         nil,
+			desiredIgnore: []string{
+				"a1", "a2", // the values from different services are merged to be ignored
+			},
+			desiredAnnotations: map[string]string{
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+		},
+		{
+			name:                        "One Lb and one ClusterIP svc (pxc-like experience) with different cloud provider's defined annotations",
+			lbcs:                        []client.Object{},
+			services:                    servicesListTwoSvcs(t, dbName, namespace, map[string]string{"a1": "val1"}, map[string]string{"a2": "val2"}, corev1.ServiceTypeClusterIP, corev1.ServiceTypeLoadBalancer),
+			db:                          db(t, dbName, namespace, "", everestv1alpha1.ExposeTypeExternal),
+			existingUpstreamAnnotations: map[string]string{},
+			err:                         nil,
+			desiredIgnore: []string{
+				"a2", // the value from ClusterIP service is not included
+			},
+			desiredAnnotations: map[string]string{
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+		},
+		{
+			name:                        "Two ClusterIP svcs (pxc-like experience) with different cloud provider's defined annotations",
+			lbcs:                        []client.Object{},
+			services:                    servicesListTwoSvcs(t, dbName, namespace, map[string]string{"a1": "val1"}, map[string]string{"a2": "val2"}, corev1.ServiceTypeClusterIP, corev1.ServiceTypeClusterIP),
+			db:                          db(t, dbName, namespace, "", everestv1alpha1.ExposeTypeExternal),
+			existingUpstreamAnnotations: map[string]string{},
+			err:                         nil,
+			desiredIgnore:               []string{}, // empty because the svc type is not LB, so no annotations are included to ingnore
+			desiredAnnotations: map[string]string{
+				consts.DefaultEverestExposeServiceAnnotationsKey: consts.DefaultEverestExposeServiceAnnotationsValue,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fakeClient(t, tc.lbcs, tc.services)
+			desiredAnnotations, ignore, err := ReconcileExposureAnnotations(ctx, client, tc.db, tc.existingUpstreamAnnotations, "")
+			if tc.err == nil {
+				require.NoError(t, err)
+			} else {
+				require.Equal(t, tc.err, err)
+			}
+			assert.Equal(t, tc.desiredAnnotations, desiredAnnotations)
+			assert.Equal(t, tc.desiredIgnore, ignore)
+		})
+	}
+
+}
+
+func fakeClient(t *testing.T, objects []client.Object, lists []client.ObjectList) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(everestv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).WithLists(lists...).Build()
+}
+
+func db(t *testing.T, dbName, namespace, lbcName string, exposeType everestv1alpha1.ExposeType) *everestv1alpha1.DatabaseCluster {
+	t.Helper()
+	return &everestv1alpha1.DatabaseCluster{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dbName,
+			Namespace: namespace,
+		},
+		Spec: everestv1alpha1.DatabaseClusterSpec{
+			Proxy: everestv1alpha1.Proxy{
+				Expose: everestv1alpha1.Expose{
+					Type:                   exposeType,
+					LoadBalancerConfigName: lbcName,
+				},
+			},
+		},
+	}
+}
+
+func servicesList(t *testing.T, dbName, namespace string, annotations map[string]string, serviceType corev1.ServiceType) []client.ObjectList {
+	t.Helper()
+	return []client.ObjectList{&corev1.ServiceList{
+		Items: []corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Labels: map[string]string{
+						consts.ExposureSvcLabel: dbName,
+						consts.ComponentLabel:   "",
+					},
+					Annotations: annotations,
+				},
+				Spec: corev1.ServiceSpec{
+					Type: serviceType,
+				},
+			},
+		},
+	}}
+}
+
+func servicesListTwoSvcs(t *testing.T, dbName, namespace string, annotations1, annotations2 map[string]string, serviceType1, serviceType2 corev1.ServiceType) []client.ObjectList {
+	t.Helper()
+	return []client.ObjectList{&corev1.ServiceList{
+		Items: []corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "n1",
+					Namespace: namespace,
+					Labels: map[string]string{
+						consts.ExposureSvcLabel: dbName,
+						consts.ComponentLabel:   "",
+					},
+					Annotations: annotations1,
+				},
+				Spec: corev1.ServiceSpec{
+					Type: serviceType1,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "n2",
+					Namespace: namespace,
+					Labels: map[string]string{
+						consts.ExposureSvcLabel: dbName,
+						consts.ComponentLabel:   "",
+					},
+					Annotations: annotations2,
+				},
+				Spec: corev1.ServiceSpec{
+					Type: serviceType2,
+				},
+			},
+		},
+	}}
+}
+
+func lbcs(t *testing.T, lbcName string, annotations map[string]string) []client.Object {
+	t.Helper()
+	return []client.Object{&everestv1alpha1.LoadBalancerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: lbcName,
+		},
+		Spec: everestv1alpha1.LoadBalancerConfigSpec{
+			Annotations: annotations,
+		},
+	}}
+}

--- a/internal/controller/common/exposure_annotations_test.go
+++ b/internal/controller/common/exposure_annotations_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
-	"github.com/percona/everest-operator/internal/consts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +12,9 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	everestv1alpha1 "github.com/percona/everest-operator/api/v1alpha1"
+	"github.com/percona/everest-operator/internal/consts"
 )
 
 func TestReconcileExposureAnnotations(t *testing.T) {
@@ -223,7 +224,6 @@ func TestReconcileExposureAnnotations(t *testing.T) {
 			assert.Equal(t, tc.desiredIgnore, ignore)
 		})
 	}
-
 }
 
 func fakeClient(t *testing.T, objects []client.Object, lists []client.ObjectList) client.Client {

--- a/internal/controller/common/helper.go
+++ b/internal/controller/common/helper.go
@@ -625,24 +625,6 @@ func GetLoadBalancerConfig(
 	return lbc, nil
 }
 
-// GetAnnotations returns annotations from the LoadBalancerConfig used in the given DB.
-func GetAnnotations(
-	ctx context.Context,
-	c client.Client,
-	database *everestv1alpha1.DatabaseCluster,
-) (map[string]string, error) {
-	lbc, err := GetLoadBalancerConfig(ctx, c, database)
-	if err != nil {
-		if errors.Is(err, ErrEmptyLbc) {
-			return map[string]string{}, nil
-		}
-
-		return nil, err
-	}
-
-	return lbc.Spec.Annotations, nil
-}
-
 // GetPodSchedulingPolicy returns the PodSchedulingPolicy object by name.
 func GetPodSchedulingPolicy(ctx context.Context, c client.Client, pspName string) (*everestv1alpha1.PodSchedulingPolicy, error) {
 	psp := &everestv1alpha1.PodSchedulingPolicy{}

--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -188,12 +188,11 @@ func (p *applier) Proxy() error {
 			LoadBalancerSourceRanges: p.DB.Spec.Proxy.Expose.IPSourceRangesStringArray(),
 		}
 
-		annotations, err := common.GetAnnotations(p.ctx, p.C, p.DB)
+		desiredAnnotations, _, err := common.ReconcileExposureAnnotations(p.ctx, p.C, p.DB, pg.Spec.Proxy.PGBouncer.ServiceExpose.Annotations, consts.PGBouncerComponentLabelValue)
 		if err != nil {
 			return err
 		}
-
-		pg.Spec.Proxy.PGBouncer.ServiceExpose.Annotations = annotations
+		pg.Spec.Proxy.PGBouncer.ServiceExpose.Annotations = desiredAnnotations
 	default:
 		return fmt.Errorf("invalid expose type %s", database.Spec.Proxy.Expose.Type)
 	}

--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -194,7 +194,8 @@ func (p *applier) Proxy() error {
 			LoadBalancerSourceRanges: p.DB.Spec.Proxy.Expose.IPSourceRangesStringArray(),
 		}
 
-		desiredAnnotations, _, err := common.ReconcileExposureAnnotations(p.ctx, p.C, p.DB, pg.Spec.Proxy.PGBouncer.ServiceExpose.Annotations, consts.PGBouncerComponentLabelValue)
+		desiredAnnotations, _, err := common.ReconcileExposureAnnotations(
+			p.ctx, p.C, p.DB, pg.Spec.Proxy.PGBouncer.ServiceExpose.Annotations, consts.PGBouncerComponentLabelValue)
 		if err != nil {
 			return err
 		}

--- a/internal/controller/providers/psmdb/applier.go
+++ b/internal/controller/providers/psmdb/applier.go
@@ -259,47 +259,47 @@ func (p *applier) Proxy() error {
 
 func (p *applier) exposeShardedCluster(expose *psmdbv1.MongosExpose) error {
 	database := p.DB
+	desiredAnnotations, ignore, err := common.ReconcileExposureAnnotations(p.ctx, p.C, p.DB, p.PerconaServerMongoDB.Spec.Sharding.Mongos.Expose.ServiceAnnotations, consts.PSMDBShardedComponentLabelValue)
+	if err != nil {
+		return err
+	}
+
 	switch database.Spec.Proxy.Expose.Type {
 	case everestv1alpha1.ExposeTypeInternal:
 		expose.ExposeType = corev1.ServiceTypeClusterIP
-		expose.ServiceAnnotations = map[string]string{}
+		expose.ServiceAnnotations = desiredAnnotations
 	case everestv1alpha1.ExposeTypeExternal:
 		expose.ExposeType = corev1.ServiceTypeLoadBalancer
 		expose.LoadBalancerSourceRanges = database.Spec.Proxy.Expose.IPSourceRangesStringArray()
-
-		annotations, err := common.GetAnnotations(p.ctx, p.C, p.DB)
-		if err != nil {
-			return err
-		}
-
-		expose.ServiceAnnotations = annotations
+		expose.ServiceAnnotations = desiredAnnotations
 	default:
 		return fmt.Errorf("invalid expose type %s", database.Spec.Proxy.Expose.Type)
 	}
+	p.PerconaServerMongoDB.Spec.IgnoreAnnotations = ignore
 	return nil
 }
 
 func (p *applier) exposeDefaultReplSet(expose *psmdbv1.ExposeTogglable) error {
 	database := p.DB
+	desiredAnnotations, ignore, err := common.ReconcileExposureAnnotations(p.ctx, p.C, p.DB, p.PerconaServerMongoDB.Spec.Replsets[0].Expose.ServiceAnnotations, consts.PSMDBReplicasetComponentLabelValue)
+	if err != nil {
+		return err
+	}
+
 	switch database.Spec.Proxy.Expose.Type {
 	case everestv1alpha1.ExposeTypeInternal:
 		expose.Enabled = true
 		expose.ExposeType = corev1.ServiceTypeClusterIP
-		expose.ServiceAnnotations = map[string]string{}
+		expose.ServiceAnnotations = desiredAnnotations
 	case everestv1alpha1.ExposeTypeExternal:
 		expose.Enabled = true
 		expose.ExposeType = corev1.ServiceTypeLoadBalancer
 		expose.LoadBalancerSourceRanges = database.Spec.Proxy.Expose.IPSourceRangesStringArray()
-
-		annotations, err := common.GetAnnotations(p.ctx, p.C, p.DB)
-		if err != nil {
-			return err
-		}
-
-		expose.ServiceAnnotations = annotations
+		expose.ServiceAnnotations = desiredAnnotations
 	default:
 		return fmt.Errorf("invalid expose type %s", database.Spec.Proxy.Expose.Type)
 	}
+	p.PerconaServerMongoDB.Spec.IgnoreAnnotations = ignore
 	return nil
 }
 

--- a/internal/controller/providers/psmdb/applier.go
+++ b/internal/controller/providers/psmdb/applier.go
@@ -262,7 +262,8 @@ func (p *applier) Proxy() error {
 
 func (p *applier) exposeShardedCluster(expose *psmdbv1.MongosExpose) error {
 	database := p.DB
-	desiredAnnotations, ignore, err := common.ReconcileExposureAnnotations(p.ctx, p.C, p.DB, p.PerconaServerMongoDB.Spec.Sharding.Mongos.Expose.ServiceAnnotations, consts.PSMDBShardedComponentLabelValue)
+	desiredAnnotations, ignore, err := common.ReconcileExposureAnnotations(
+		p.ctx, p.C, p.DB, p.Spec.Sharding.Mongos.Expose.ServiceAnnotations, consts.PSMDBShardedComponentLabelValue)
 	if err != nil {
 		return err
 	}
@@ -278,13 +279,14 @@ func (p *applier) exposeShardedCluster(expose *psmdbv1.MongosExpose) error {
 	default:
 		return fmt.Errorf("invalid expose type %s", database.Spec.Proxy.Expose.Type)
 	}
-	p.PerconaServerMongoDB.Spec.IgnoreAnnotations = ignore
+	p.Spec.IgnoreAnnotations = ignore
 	return nil
 }
 
 func (p *applier) exposeDefaultReplSet(expose *psmdbv1.ExposeTogglable) error {
 	database := p.DB
-	desiredAnnotations, ignore, err := common.ReconcileExposureAnnotations(p.ctx, p.C, p.DB, p.PerconaServerMongoDB.Spec.Replsets[0].Expose.ServiceAnnotations, consts.PSMDBReplicasetComponentLabelValue)
+	desiredAnnotations, ignore, err := common.ReconcileExposureAnnotations(
+		p.ctx, p.C, p.DB, p.Spec.Replsets[0].Expose.ServiceAnnotations, consts.PSMDBReplicasetComponentLabelValue)
 	if err != nil {
 		return err
 	}
@@ -302,7 +304,7 @@ func (p *applier) exposeDefaultReplSet(expose *psmdbv1.ExposeTogglable) error {
 	default:
 		return fmt.Errorf("invalid expose type %s", database.Spec.Proxy.Expose.Type)
 	}
-	p.PerconaServerMongoDB.Spec.IgnoreAnnotations = ignore
+	p.Spec.IgnoreAnnotations = ignore
 	return nil
 }
 

--- a/internal/controller/providers/pxc/applier.go
+++ b/internal/controller/providers/pxc/applier.go
@@ -451,7 +451,8 @@ func (p *applier) applyHAProxyCfg() error {
 	} else {
 		haProxy.PodSpec.Size = *p.DB.Spec.Proxy.Replicas
 	}
-	desiredAnnotations, ignore, err := common.ReconcileExposureAnnotations(p.ctx, p.C, p.DB, p.PerconaXtraDBCluster.Spec.HAProxy.ExposePrimary.Annotations, consts.HAProxyComponentLabelValue)
+	desiredAnnotations, ignore, err := common.ReconcileExposureAnnotations(
+		p.ctx, p.C, p.DB, p.Spec.HAProxy.ExposePrimary.Annotations, consts.HAProxyComponentLabelValue)
 	if err != nil {
 		return err
 	}
@@ -472,7 +473,7 @@ func (p *applier) applyHAProxyCfg() error {
 			LoadBalancerSourceRanges: p.DB.Spec.Proxy.Expose.IPSourceRangesStringArray(),
 			Annotations:              desiredAnnotations,
 		}
-		p.PerconaXtraDBCluster.Spec.IgnoreAnnotations = ignore
+		p.Spec.IgnoreAnnotations = ignore
 		haProxy.ExposePrimary = expose
 		haProxy.ExposeReplicas = &pxcv1.ReplicasServiceExpose{ServiceExpose: expose}
 	default:
@@ -549,7 +550,7 @@ func (p *applier) applyHAProxyCfg() error {
 		}
 	}
 
-	p.PerconaXtraDBCluster.Spec.IgnoreAnnotations = ignore
+	p.Spec.IgnoreAnnotations = ignore
 	p.PerconaXtraDBCluster.Spec.HAProxy = haProxy
 	return nil
 }
@@ -568,7 +569,8 @@ func (p *applier) applyProxySQLCfg() error {
 	} else {
 		proxySQL.Size = *p.DB.Spec.Proxy.Replicas
 	}
-	desiredAnnotations, ignore, err := common.ReconcileExposureAnnotations(p.ctx, p.C, p.DB, p.PerconaXtraDBCluster.Spec.ProxySQL.Expose.Annotations, consts.ProxySQLComponentLabelValue)
+	desiredAnnotations, ignore, err := common.ReconcileExposureAnnotations(
+		p.ctx, p.C, p.DB, p.Spec.ProxySQL.Expose.Annotations, consts.ProxySQLComponentLabelValue)
 	if err != nil {
 		return err
 	}
@@ -641,7 +643,7 @@ func (p *applier) applyProxySQLCfg() error {
 			proxySQL.Resources.Requests[corev1.ResourceMemory] = p.DB.Spec.Proxy.Resources.Memory
 		}
 	}
-	p.PerconaXtraDBCluster.Spec.IgnoreAnnotations = ignore
+	p.Spec.IgnoreAnnotations = ignore
 	p.PerconaXtraDBCluster.Spec.ProxySQL = proxySQL
 	return nil
 }

--- a/internal/controller/providers/pxc/applier.go
+++ b/internal/controller/providers/pxc/applier.go
@@ -449,27 +449,28 @@ func (p *applier) applyHAProxyCfg() error {
 	} else {
 		haProxy.PodSpec.Size = *p.DB.Spec.Proxy.Replicas
 	}
+	desiredAnnotations, ignore, err := common.ReconcileExposureAnnotations(p.ctx, p.C, p.DB, p.PerconaXtraDBCluster.Spec.HAProxy.ExposePrimary.Annotations, consts.HAProxyComponentLabelValue)
+	if err != nil {
+		return err
+	}
 
 	switch p.DB.Spec.Proxy.Expose.Type {
 	case everestv1alpha1.ExposeTypeInternal:
 		expose := pxcv1.ServiceExpose{
 			Enabled:     true,
 			Type:        corev1.ServiceTypeClusterIP,
-			Annotations: map[string]string{},
+			Annotations: desiredAnnotations,
 		}
 		haProxy.ExposePrimary = expose
 		haProxy.ExposeReplicas = &pxcv1.ReplicasServiceExpose{ServiceExpose: expose}
 	case everestv1alpha1.ExposeTypeExternal:
-		annotations, err := common.GetAnnotations(p.ctx, p.C, p.DB)
-		if err != nil {
-			return err
-		}
 		expose := pxcv1.ServiceExpose{
 			Enabled:                  true,
 			Type:                     corev1.ServiceTypeLoadBalancer,
 			LoadBalancerSourceRanges: p.DB.Spec.Proxy.Expose.IPSourceRangesStringArray(),
-			Annotations:              annotations,
+			Annotations:              desiredAnnotations,
 		}
+		p.PerconaXtraDBCluster.Spec.IgnoreAnnotations = ignore
 		haProxy.ExposePrimary = expose
 		haProxy.ExposeReplicas = &pxcv1.ReplicasServiceExpose{ServiceExpose: expose}
 	default:
@@ -545,6 +546,7 @@ func (p *applier) applyHAProxyCfg() error {
 		}
 	}
 
+	p.PerconaXtraDBCluster.Spec.IgnoreAnnotations = ignore
 	p.PerconaXtraDBCluster.Spec.HAProxy = haProxy
 	return nil
 }
@@ -563,25 +565,25 @@ func (p *applier) applyProxySQLCfg() error {
 	} else {
 		proxySQL.Size = *p.DB.Spec.Proxy.Replicas
 	}
+	desiredAnnotations, ignore, err := common.ReconcileExposureAnnotations(p.ctx, p.C, p.DB, p.PerconaXtraDBCluster.Spec.ProxySQL.Expose.Annotations, consts.ProxySQLComponentLabelValue)
+	if err != nil {
+		return err
+	}
 
 	switch p.DB.Spec.Proxy.Expose.Type {
 	case everestv1alpha1.ExposeTypeInternal:
 		expose := pxcv1.ServiceExpose{
 			Enabled:     true,
 			Type:        corev1.ServiceTypeClusterIP,
-			Annotations: map[string]string{},
+			Annotations: desiredAnnotations,
 		}
 		proxySQL.Expose = expose
 	case everestv1alpha1.ExposeTypeExternal:
-		annotations, err := common.GetAnnotations(p.ctx, p.C, p.DB)
-		if err != nil {
-			return err
-		}
 		expose := pxcv1.ServiceExpose{
 			Enabled:                  true,
 			Type:                     corev1.ServiceTypeLoadBalancer,
 			LoadBalancerSourceRanges: p.DB.Spec.Proxy.Expose.IPSourceRangesStringArray(),
-			Annotations:              annotations,
+			Annotations:              desiredAnnotations,
 		}
 		proxySQL.Expose = expose
 	default:
@@ -636,6 +638,7 @@ func (p *applier) applyProxySQLCfg() error {
 			proxySQL.Resources.Requests[corev1.ResourceMemory] = p.DB.Spec.Proxy.Resources.Memory
 		}
 	}
+	p.PerconaXtraDBCluster.Spec.IgnoreAnnotations = ignore
 	p.PerconaXtraDBCluster.Spec.ProxySQL = proxySQL
 	return nil
 }

--- a/utils/finalizers.go
+++ b/utils/finalizers.go
@@ -14,8 +14,6 @@
 // limitations under the License.
 
 // Package utils ...
-//
-
 package utils
 
 import (

--- a/utils/validators_test.go
+++ b/utils/validators_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+package utils //nolint:revive
 
 import (
 	"testing"


### PR DESCRIPTION
**Handle existing providers annotations**
---
**Problem:**
EVEREST-2268

As it turned out during discussion with the cloud team there are 3 issues:
1. annotations can't be completely deleted from `pxc` and `psmdb` services. Assigning an empty map to the expose.annotations section is not efficient by design. 
2. the cloud providers could set their own annotations to LoadBalancers independently and we need to keep them
3. if we use any custom annotations in `pxc` and `psmdb` they will rewrite the existing annotations in the service. To avoid that we need to put the annotations we want to persist to the `ignore` section of the cluster spec. 


**Solution:**
- To allow annotations deletion, from now on the everest-operator always applies the `everest.percona.com/custom-annotations=true` annotation to the exposure section of the upstream PR. It does nothing but takes place in the annotations map so that we could cleanup the custom annotations list efficiently, overcoming the upstream limitation. 
- everest-operator figures out the list of the annotations already applied to the exposure service and puts all annotations that are not listed in the `expose.annotations` of the upstream CR to the `ignore` section of the upstream CR . Only then we update the upstream CR `expose.annotation` section itself. So we make sure that we populated the `ignore` section before we update the `expose.annotations` section to avoid overwriting the existing annotations in the services. 
- DB controller watches Services annotations update and reconciles the related DB in case the service annotations have changed

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
