### PR TITLE
EVEREST-2279 | [BUG] TLS cert watcher is not started

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -161,6 +161,7 @@ func main() {
 		tlsOpts = append(tlsOpts, disableHTTP2)
 	}
 
+	ctx := ctrl.SetupSignalHandler()
 	if cfg.WebhookCertPath != "" {
 		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
 			"webhook-cert-path", cfg.WebhookCertPath, "webhook-cert-name", cfg.WebhookCertName, "webhook-cert-key", cfg.WebhookCertKey)
@@ -174,6 +175,13 @@ func main() {
 			setupLog.Error(err, "Failed to initialize webhook certificate watcher")
 			os.Exit(1)
 		}
+
+		go func() {
+			if err := webhookCertWatcher.Start(ctx); err != nil {
+				setupLog.Error(err, "Failed to start webhook certificate watcher")
+				os.Exit(1)
+			}
+		}()
 
 		tlsOpts = append(tlsOpts, func(config *tls.Config) {
 			config.GetCertificate = webhookCertWatcher.GetCertificate
@@ -356,7 +364,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-2279

When updating the TLS certificate secret, Everest operator is not able to watch the change and refresh the certificate used by the admission webhook server.

**Cause:**
The TLS cert watcher is not started.

**Solution:**

Call `webhookCertwatcher.Start(..)`

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
