### PR TITLE
EVEREST-2282 Set image pull policy for new DB clusters only

### DIFF
--- a/internal/controller/common/helper.go
+++ b/internal/controller/common/helper.go
@@ -674,6 +674,12 @@ func IsDatabaseClusterRestoreRunning(
 	}), nil
 }
 
+// IsNewDatabaseCluster returns true if the database is in a new or init state.
+func IsNewDatabaseCluster(dbState everestv1alpha1.AppState) bool {
+	dbState = dbState.WithCreatingState()
+	return dbState == everestv1alpha1.AppStateCreating || dbState == everestv1alpha1.AppStateInit
+}
+
 // GetRepoNameByBackupStorage returns the name of the repo that corresponds to the given backup storage.
 func GetRepoNameByBackupStorage(
 	backupStorage *everestv1alpha1.BackupStorage,

--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -113,7 +113,11 @@ func (p *applier) Engine() error {
 	}
 
 	pg.Spec.Image = pgEngineVersion.ImagePath
-	pg.Spec.ImagePullPolicy = corev1.PullIfNotPresent
+	// Set image pull policy explicitly only in case this is a new cluster.
+	// This will prevent changing the image pull policy on upgrades and no DB restart will be triggered.
+	if common.IsNewDatabaseCluster(p.DB.Status.Status) {
+		pg.Spec.ImagePullPolicy = corev1.PullIfNotPresent
+	}
 
 	pgMajorVersionMatch := regexp.
 		MustCompile(`^(\d+)`).
@@ -154,8 +158,12 @@ func (p *applier) Engine() error {
 	}
 
 	pg.Spec.Extensions = pgv2.ExtensionsSpec{
-		Image:           image,
-		ImagePullPolicy: corev1.PullIfNotPresent,
+		Image: image,
+	}
+	// Set image pull policy explicitly only in case this is a new cluster.
+	// This will prevent changing the image pull policy on upgrades and no DB restart will be triggered.
+	if common.IsNewDatabaseCluster(p.DB.Status.Status) {
+		pg.Spec.Extensions.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 
 	return nil
@@ -340,11 +348,15 @@ func (p *applier) applyPMMCfg(monitoring *everestv1alpha1.MonitoringConfig) erro
 	ctx := p.ctx
 
 	pg.Spec.PMM = &pgv2.PMMSpec{
-		Enabled:         true,
-		Resources:       common.GetPMMResources(pointer.Get(database.Spec.Monitoring), database.Spec.Engine.Size()),
-		Secret:          fmt.Sprintf("%s%s-pmm", consts.EverestSecretsPrefix, database.GetName()),
-		Image:           common.DefaultPMMClientImage,
-		ImagePullPolicy: corev1.PullIfNotPresent,
+		Enabled:   true,
+		Resources: common.GetPMMResources(pointer.Get(database.Spec.Monitoring), database.Spec.Engine.Size()),
+		Secret:    fmt.Sprintf("%s%s-pmm", consts.EverestSecretsPrefix, database.GetName()),
+		Image:     common.DefaultPMMClientImage,
+	}
+	// Set image pull policy explicitly only in case this is a new cluster.
+	// This will prevent changing the image pull policy on upgrades and no DB restart will be triggered.
+	if common.IsNewDatabaseCluster(p.DB.Status.Status) {
+		pg.Spec.PMM.ImagePullPolicy = corev1.PullIfNotPresent
 	}
 
 	if monitoring.Spec.PMM.Image != "" {

--- a/internal/controller/providers/psmdb/applier.go
+++ b/internal/controller/providers/psmdb/applier.go
@@ -114,7 +114,11 @@ func (p *applier) Engine() error {
 	}
 
 	psmdb.Spec.Image = engineVersion.ImagePath
-	psmdb.Spec.ImagePullPolicy = corev1.PullIfNotPresent
+	// Set image pull policy explicitly only in case this is a new cluster.
+	// This will prevent changing the image pull policy on upgrades and no DB restart will be triggered.
+	if common.IsNewDatabaseCluster(p.DB.Status.Status) {
+		psmdb.Spec.ImagePullPolicy = corev1.PullIfNotPresent
+	}
 
 	psmdb.Spec.Secrets = &psmdbv1.SecretsSpec{
 		Users:         database.Spec.Engine.UserSecretsName,


### PR DESCRIPTION
**Problem:**
EVEREST-2282

*Short explanation of the problem.*
In https://github.com/percona/everest-operator/pull/868 image pull policy was changed unconditionally to `IfNotPresent`. But during the upgrade of Everest installation it leads to DB cluster restarts.

**Solution:**

Set image pull policy=`IfNotPresent` only for new DB clusters. Old ones are kept untouched.

