### PR TITLE
EVEREST-2301 | Cannot change proxy expose method from external to internal

### DIFF
--- a/api/v1alpha1/databasecluster_types.go
+++ b/api/v1alpha1/databasecluster_types.go
@@ -263,7 +263,7 @@ type Proxy struct {
 	// Config is the proxy configuration
 	Config string `json:"config,omitempty"`
 	// Expose is the proxy expose configuration
-	// +kubebuilder:validation:XValidation:rule="!has(oldSelf.loadBalancerConfigName) || oldSelf.loadBalancerConfigName == '' || (has(self.loadBalancerConfigName) && self.loadBalancerConfigName != '')",message=".spec.proxy.expose.loadBalancerConfigName cannot be cleared once set"
+	// +kubebuilder:validation:XValidation:rule="self.type == 'internal' || !has(oldSelf.loadBalancerConfigName) || oldSelf.loadBalancerConfigName == '' || (has(self.loadBalancerConfigName) && self.loadBalancerConfigName != '')",message=".spec.proxy.expose.loadBalancerConfigName cannot be cleared once set"
 	Expose Expose `json:"expose,omitempty"`
 	// Resources are the resource limits for each proxy replica.
 	// If not set, resource limits are not imposed

--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -78,7 +78,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-09-10T10:37:30Z"
+    createdAt: "2025-09-15T08:59:33Z"
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: everest-operator.v0.0.0

--- a/bundle/manifests/everest.percona.com_databaseclusters.yaml
+++ b/bundle/manifests/everest.percona.com_databaseclusters.yaml
@@ -444,9 +444,9 @@ spec:
                     x-kubernetes-validations:
                     - message: .spec.proxy.expose.loadBalancerConfigName cannot be
                         cleared once set
-                      rule: '!has(oldSelf.loadBalancerConfigName) || oldSelf.loadBalancerConfigName
-                        == '''' || (has(self.loadBalancerConfigName) && self.loadBalancerConfigName
-                        != '''')'
+                      rule: self.type == 'internal' || !has(oldSelf.loadBalancerConfigName)
+                        || oldSelf.loadBalancerConfigName == '' || (has(self.loadBalancerConfigName)
+                        && self.loadBalancerConfigName != '')
                   replicas:
                     description: Replicas is the number of proxy replicas
                     format: int32

--- a/config/crd/bases/everest.percona.com_databaseclusters.yaml
+++ b/config/crd/bases/everest.percona.com_databaseclusters.yaml
@@ -444,9 +444,9 @@ spec:
                     x-kubernetes-validations:
                     - message: .spec.proxy.expose.loadBalancerConfigName cannot be
                         cleared once set
-                      rule: '!has(oldSelf.loadBalancerConfigName) || oldSelf.loadBalancerConfigName
-                        == '''' || (has(self.loadBalancerConfigName) && self.loadBalancerConfigName
-                        != '''')'
+                      rule: self.type == 'internal' || !has(oldSelf.loadBalancerConfigName)
+                        || oldSelf.loadBalancerConfigName == '' || (has(self.loadBalancerConfigName)
+                        && self.loadBalancerConfigName != '')
                   replicas:
                     description: Replicas is the number of proxy replicas
                     format: int32

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -816,9 +816,9 @@ spec:
                     x-kubernetes-validations:
                     - message: .spec.proxy.expose.loadBalancerConfigName cannot be
                         cleared once set
-                      rule: '!has(oldSelf.loadBalancerConfigName) || oldSelf.loadBalancerConfigName
-                        == '''' || (has(self.loadBalancerConfigName) && self.loadBalancerConfigName
-                        != '''')'
+                      rule: self.type == 'internal' || !has(oldSelf.loadBalancerConfigName)
+                        || oldSelf.loadBalancerConfigName == '' || (has(self.loadBalancerConfigName)
+                        && self.loadBalancerConfigName != '')
                   replicas:
                     description: Replicas is the number of proxy replicas
                     format: int32


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-2301

Once we set the proxy expose method to `external`, we cannot change it back to `internal`. We get the error:

```
DatabaseCluster.everest.percona.com \"mysql-xw0\" is invalid: spec.proxy.expose: Invalid value: \"object\": .spec.proxy.expose.loadBalancerConfigName cannot be cleared once set"
```

**Cause:**

In https://github.com/percona/everest-operator/pull/878 we added a check to ensure that `.spec.proxy.expose.loadBalancerConfigName` cannot be cleared once set. However, this should allowed if the expose type is being changed to `internal` (ClusterIP)

**Solution:**

The check should be ignored when the expose method is `internal`

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
