### PR TITLE
EVEREST-1319 Remove pvc for new versions

### DIFF
--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/AlekSi/pointer"
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-ini/ini"
 	pgv2 "github.com/percona/percona-postgresql-operator/pkg/apis/pgv2.percona.com/v2"
 	crunchyv1beta1 "github.com/percona/percona-postgresql-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
@@ -1048,6 +1049,7 @@ func (p *applier) reconcilePGBackupsSpec() (pgv2.Backups, error) {
 		backupStoragesSecrets,
 		database.Spec.Engine.Storage,
 		database,
+		checkPVCRequired(oldBackups.PGBackRest.Repos, engine.Status.OperatorVersion),
 	)
 	if err != nil {
 		return pgv2.Backups{}, err
@@ -1079,6 +1081,21 @@ func (p *applier) reconcilePGBackupsSpec() (pgv2.Backups, error) {
 	newBackups.PGBackRest.Repos = pgBackrestRepos
 	newBackups.PGBackRest.Global = pgBackrestGlobal
 	return newBackups, nil
+}
+
+// Keep the PVC storage only if it was defined before or if PG less than 2.7.0 is used
+func checkPVCRequired(repos []crunchyv1beta1.PGBackRestRepo, v string) bool {
+	for _, repo := range repos {
+		if repo.Volume != nil {
+			return true
+		}
+	}
+
+	if version, err := semver.NewVersion(v); err == nil {
+		return version.LessThan(semver.MustParse("2.7.0"))
+	}
+
+	return false
 }
 
 // createPGBackrestSecret creates or updates the PG Backrest secret.
@@ -1126,13 +1143,14 @@ func reconcilePGBackRestRepos(
 	backupStoragesSecrets map[string]*corev1.Secret,
 	engineStorage everestv1alpha1.Storage,
 	db *everestv1alpha1.DatabaseCluster,
+	pvcRequired bool,
 ) (
 	[]crunchyv1beta1.PGBackRestRepo,
 	map[string]string,
 	[]byte,
 	error,
 ) {
-	reposReconciler, err := newPGReposReconciler(oldRepos, backupSchedules)
+	reposReconciler, err := newPGReposReconciler(oldRepos, backupSchedules, pvcRequired)
 	if err != nil {
 		return []crunchyv1beta1.PGBackRestRepo{}, map[string]string{}, []byte{},
 			errors.Join(err, errors.New("failed to initialize PGBackrest repos reconciler"))
@@ -1161,7 +1179,7 @@ func reconcilePGBackRestRepos(
 			errors.Join(err, errors.New("failed to add new backup schedules"))
 	}
 
-	newRepos, err := reposReconciler.addDefaultRepo(engineStorage)
+	newRepos, err := reposReconciler.addDefaultRepo(engineStorage, pvcRequired)
 	if err != nil {
 		return []crunchyv1beta1.PGBackRestRepo{}, map[string]string{}, []byte{}, err
 	}

--- a/internal/controller/providers/pg/pg_test.go
+++ b/internal/controller/providers/pg/pg_test.go
@@ -293,6 +293,72 @@ func TestReconcilePGBackRestReposEmptyAddRequest(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposEmptyAddRequest_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testRepos := []crunchyv1beta1.PGBackRestRepo{}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "backupStorage1",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -378,6 +444,77 @@ func TestReconcilePGBackRestReposEmptyAddSchedule(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposEmptyAddSchedule_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testRepos := []crunchyv1beta1.PGBackRestRepo{}
+	testSchedule := "0 0 * * *"
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          testSchedule,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule,
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -488,6 +625,86 @@ func TestReconcilePGBackRestReposSameStorageOneRequestAddRequest(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposSameStorageOneRequestAddRequest_NoPCVRequired(t *testing.T) {
+	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "backupStorage1",
+			},
+		},
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "backupStorage1",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -604,6 +821,92 @@ func TestReconcilePGBackRestReposSameStorageOneRequestAddSchedule(t *testing.T) 
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposSameStorageOneRequestAddSchedule_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+		},
+	}
+	testSchedule := "0 0 * * *"
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          testSchedule,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "backupStorage1",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule,
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -723,6 +1026,95 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleAddRequest(t *testing.T) 
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposSameStorageOneScheduleAddRequest_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule := "0 0 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          testSchedule,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "backupStorage1",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule,
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -854,6 +1246,107 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleAddSchedule(t *testing.T)
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposSameStorageOneScheduleAddSchedule_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule1 := "0 0 * * *"
+	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          testSchedule1,
+			BackupStorageName: "backupStorage1",
+		},
+		{
+			Enabled:           true,
+			Name:              "schedule2",
+			Schedule:          testSchedule2,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -995,6 +1488,117 @@ func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddRequest(t *testin
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddRequest_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule := "0 0 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          testSchedule,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "backupStorage2",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+		"backupStorage2": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket2",
+				Region:      "region2",
+				EndpointURL: "endpoint2",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+		"backupStorage2": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule,
+			},
+		},
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket2",
+				Region:   "region2",
+				Endpoint: "endpoint2",
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -1140,6 +1744,121 @@ func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddSchedule(t *testi
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddSchedule_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule1 := "0 0 * * *"
+	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          testSchedule1,
+			BackupStorageName: "backupStorage1",
+		},
+		{
+			Enabled:           true,
+			Name:              "schedule2",
+			Schedule:          testSchedule2,
+			BackupStorageName: "backupStorage2",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+		"backupStorage2": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket2",
+				Region:      "region2",
+				EndpointURL: "endpoint2",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+		"backupStorage2": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket2",
+				Region:   "region2",
+				Endpoint: "endpoint2",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -1285,6 +2004,121 @@ func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddScheduleNoOrder(t
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddScheduleNoOrder_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule1 := "0 0 * * *"
+	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket2",
+				Region:   "region2",
+				Endpoint: "endpoint2",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          testSchedule1,
+			BackupStorageName: "backupStorage1",
+		},
+		{
+			Enabled:           true,
+			Name:              "schedule2",
+			Schedule:          testSchedule2,
+			BackupStorageName: "backupStorage2",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+		"backupStorage2": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket2",
+				Region:      "region2",
+				EndpointURL: "endpoint2",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+		"backupStorage2": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket2",
+				Region:   "region2",
+				Endpoint: "endpoint2",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -1426,6 +2260,117 @@ func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddRequestNoOrder(t 
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposDifferentStorageOneScheduleAddRequestNoOrder_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket2",
+				Region:   "region2",
+				Endpoint: "endpoint2",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule2",
+			Schedule:          testSchedule2,
+			BackupStorageName: "backupStorage2",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "backupStorage1",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+		"backupStorage2": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket2",
+				Region:      "region2",
+				EndpointURL: "endpoint2",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+		"backupStorage2": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+		},
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket2",
+				Region:   "region2",
+				Endpoint: "endpoint2",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -1540,6 +2485,90 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleChangeSchedule(t *testing
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposSameStorageOneScheduleChangeSchedule_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule1 := "0 0 * * *"
+	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule2",
+			Schedule:          testSchedule2,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -1672,6 +2701,108 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleChangeScheduleAddSchedule
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposSameStorageOneScheduleChangeScheduleAddSchedule_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule1 := "0 0 * * *"
+	testSchedule2 := "0 1 * * *"
+	testSchedule3 := "0 2 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule2",
+			Schedule:          testSchedule2,
+			BackupStorageName: "backupStorage1",
+		},
+		{
+			Enabled:           true,
+			Name:              "schedule2",
+			Schedule:          testSchedule3,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule3,
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -1781,6 +2912,85 @@ func TestReconcilePGBackRestReposSameStorageOneScheduleDeleteScheduleAddRequest(
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposSameStorageOneScheduleDeleteScheduleAddRequest_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule := "0 0 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "backupStorage1",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -1906,6 +3116,101 @@ func TestReconcilePGBackRestReposSameStorageTwoSchedulesDelete2ndSchedule(t *tes
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposSameStorageTwoSchedulesDelete2ndSchedule_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule1 := "0 0 * * *"
+	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          testSchedule1,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -2031,6 +3336,101 @@ func TestReconcilePGBackRestReposSameStorageTwoSchedulesDelete1stSchedule(t *tes
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposSameStorageTwoSchedulesDelete1stSchedule_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule1 := "0 0 * * *"
+	testSchedule2 := "0 1 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule2",
+			Schedule:          testSchedule2,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -2110,6 +3510,54 @@ func TestReconcilePGBackRestReposOneScheduleDeleteSchedule(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposOneScheduleDeleteSchedule_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule1 := "0 0 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	var expRepos []crunchyv1beta1.PGBackRestRepo
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -2185,6 +3633,50 @@ func TestReconcilePGBackRestReposOneRequestDeleteRequest(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposOneRequestDeleteRequest_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	var expRepos []crunchyv1beta1.PGBackRestRepo
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -2313,6 +3805,7 @@ func TestReconcilePGBackRestReposSameStorageThreeSchedulesAddSchedule(t *testing
 				UID:  "123",
 			},
 		},
+		true,
 	)
 	require.Error(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -2466,6 +3959,7 @@ func TestReconcilePGBackRestReposDifferentStorageThreeRequestsAddRequest(t *test
 				UID:  "123",
 			},
 		},
+		true,
 	)
 	require.Error(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -2643,6 +4137,153 @@ func TestReconcilePGBackRestReposSameStorageThreeSchedulesAddRequest(t *testing.
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposSameStorageThreeSchedulesAddRequest_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testSchedule1 := "0 0 * * *"
+	testSchedule2 := "0 1 * * *"
+	testSchedule3 := "0 2 * * *"
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+		{
+			Name: "repo3",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule3,
+			},
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          testSchedule1,
+			BackupStorageName: "backupStorage1",
+		},
+		{
+			Enabled:           true,
+			Name:              "schedule2",
+			Schedule:          testSchedule2,
+			BackupStorageName: "backupStorage1",
+		},
+		{
+			Enabled:           true,
+			Name:              "schedule3",
+			Schedule:          testSchedule3,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "backupStorage1",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule1,
+			},
+		},
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule2,
+			},
+		},
+		{
+			Name: "repo3",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule3,
+			},
+		},
+	}
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -2682,6 +4323,7 @@ func TestReconcilePGBackRestReposUnknownStorageRequest(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
 	)
 	require.Error(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -2790,6 +4432,96 @@ func TestReconcilePGBackRestReposScheduleAfterOnDemandToAnotherStorage(t *testin
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposScheduleAfterOnDemandToAnotherStorage_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	s3Repo1 := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket1",
+	}
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3:   s3Repo1,
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{{
+		Enabled:           true,
+		Name:              "sched1",
+		Schedule:          "20 * * * *",
+		BackupStorageName: "bs2",
+	}}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{{
+		Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+			BackupStorageName: "bs1",
+		},
+	}}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"bs1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket1",
+			},
+		},
+		"bs2": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket2",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"bs1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		}, "bs2": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3:   s3Repo1,
+		},
+		{
+			Name: "repo2",
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: pointer.To("20 * * * *"),
+			},
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket: "bucket2",
+			},
+		},
+	}
+
+	repos, _, _, _ := reconcilePGBackRestRepos( //nolint:dogsled
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	assert.Equal(t, expRepos, repos)
 }
@@ -2900,6 +4632,99 @@ func TestReconcilePGBackRestReposOnDemandAfterScheduleToAnotherStorage(t *testin
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposOnDemandAfterScheduleToAnotherStorage_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	s3Repo1 := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket1",
+	}
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: pointer.To("20 * * * *"),
+			},
+			S3: s3Repo1,
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{{
+		Enabled:           true,
+		Name:              "sched1",
+		Schedule:          "20 * * * *",
+		BackupStorageName: "bs1",
+	}}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{{
+		Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+			BackupStorageName: "bs2",
+		},
+	}}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"bs1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket1",
+			},
+		},
+		"bs2": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket2",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"bs1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		}, "bs2": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: pointer.To("20 * * * *"),
+			},
+			S3: s3Repo1,
+		},
+		{
+			Name: "repo2",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket: "bucket2",
+			},
+		},
+	}
+
+	repos, _, _, _ := reconcilePGBackRestRepos( //nolint:dogsled
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	assert.Equal(t, expRepos, repos)
 }
@@ -3047,6 +4872,136 @@ func TestReconcilePGBackRestReposScheduleAfter3OnDemands(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposScheduleAfter3OnDemands_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	s3Repo1 := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket1",
+	}
+	s3Repo2 := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket2",
+	}
+	s3Repo3 := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket3",
+	}
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3:   s3Repo1,
+		},
+		{
+			Name: "repo2",
+			S3:   s3Repo2,
+		},
+		{
+			Name: "repo3",
+			S3:   s3Repo3,
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{{
+		Enabled:           true,
+		Name:              "sched1",
+		Schedule:          "20 * * * *",
+		BackupStorageName: "bs2",
+	}}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs3",
+			},
+		},
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs2",
+			},
+		},
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs1",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"bs1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket1",
+			},
+		},
+		"bs2": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket2",
+			},
+		},
+		"bs3": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket3",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"bs1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		}, "bs2": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+		"bs3": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3:   s3Repo1,
+		},
+		{
+			Name: "repo2",
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: pointer.To("20 * * * *"),
+			},
+			S3: s3Repo2,
+		},
+		{
+			Name: "repo3",
+			S3:   s3Repo3,
+		},
+	}
+
+	repos, _, _, _ := reconcilePGBackRestRepos( //nolint:dogsled
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	assert.Equal(t, expRepos, repos)
 }
@@ -3202,6 +5157,144 @@ func TestReconcilePGBackRestReposOnDemand3OnDemandsAndSchedule(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposOnDemand3OnDemandsAndSchedule_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	s3Repo1 := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket1",
+	}
+	s3Repo2 := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket2",
+	}
+	s3Repo3 := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket3",
+	}
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3:   s3Repo1,
+		},
+		{
+			Name: "repo2",
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: pointer.To("20 * * * *"),
+			},
+			S3: s3Repo2,
+		},
+		{
+			Name: "repo3",
+			S3:   s3Repo3,
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{{
+		Enabled:           true,
+		Name:              "sched1",
+		Schedule:          "20 * * * *",
+		BackupStorageName: "bs2",
+	}}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs3",
+			},
+		},
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs2",
+			},
+		},
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs1",
+			},
+		},
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs3",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"bs1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket1",
+			},
+		},
+		"bs2": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket2",
+			},
+		},
+		"bs3": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket3",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"bs1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		}, "bs2": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+		"bs3": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3:   s3Repo1,
+		},
+		{
+			Name: "repo2",
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: pointer.To("20 * * * *"),
+			},
+			S3: s3Repo2,
+		},
+		{
+			Name: "repo3",
+			S3:   s3Repo3,
+		},
+	}
+
+	repos, _, _, _ := reconcilePGBackRestRepos( //nolint:dogsled
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	assert.Equal(t, expRepos, repos)
 }
@@ -3297,6 +5390,84 @@ func TestReconcilePGBackRestBackupAndScheduleToTheSameStorage(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestBackupAndScheduleToTheSameStorage_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	s3Repo := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket1",
+	}
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: pointer.To("20 * * * *"),
+			},
+			S3: s3Repo,
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{{
+		Enabled:           true,
+		Name:              "sched1",
+		Schedule:          "20 * * * *",
+		BackupStorageName: "bs1",
+	}}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs1",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"bs1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"bs1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: pointer.To("20 * * * *"),
+			},
+			S3: s3Repo,
+		},
+	}
+
+	repos, _, _, _ := reconcilePGBackRestRepos( //nolint:dogsled
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	assert.Equal(t, expRepos, repos)
 }
@@ -3385,6 +5556,76 @@ func TestReconcilePGBackRestNewBackupAndNewScheduleToTheSameStorage(t *testing.T
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestNewBackupAndNewScheduleToTheSameStorage_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	s3Repo := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket1",
+	}
+	testRepos := []crunchyv1beta1.PGBackRestRepo{}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{{
+		Enabled:           true,
+		Name:              "sched1",
+		Schedule:          "20 * * * *",
+		BackupStorageName: "bs1",
+	}}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs1",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"bs1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"bs1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: pointer.To("20 * * * *"),
+			},
+			S3: s3Repo,
+		},
+	}
+
+	repos, _, _, _ := reconcilePGBackRestRepos( //nolint:dogsled
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	assert.Equal(t, expRepos, repos)
 }
@@ -3477,6 +5718,81 @@ func TestReconcilePGBackRestBackupAndNewScheduleToTheSameStorage(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestBackupAndNewScheduleToTheSameStorage_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	s3Repo := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket1",
+	}
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3:   s3Repo,
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{{
+		Enabled:           true,
+		Name:              "sched1",
+		Schedule:          "20 * * * *",
+		BackupStorageName: "bs1",
+	}}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs1",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"bs1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"bs1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: pointer.To("20 * * * *"),
+			},
+			S3: s3Repo,
+		},
+	}
+
+	repos, _, _, _ := reconcilePGBackRestRepos( //nolint:dogsled
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	assert.Equal(t, expRepos, repos)
 }
@@ -3517,6 +5833,7 @@ func TestReconcilePGBackRestReposUnknownStorageSchedule(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
 	)
 	require.Error(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -3567,6 +5884,42 @@ func TestReconcilePGBackRestReposEmpty(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposEmptyNoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testRepos := []crunchyv1beta1.PGBackRestRepo{}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{}
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	// no repos expected to be added
+	var expRepos []crunchyv1beta1.PGBackRestRepo
+
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expRepos, repos)
@@ -3610,8 +5963,184 @@ func TestReconcilePGBackRestReposAfterDataSource_withoutSchedule(t *testing.T) {
 				UID:  "123",
 			},
 		},
+		true,
 	)
 	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposAfterDataSource_withoutSchedule_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+
+	var testRepos []crunchyv1beta1.PGBackRestRepo
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{}
+
+	var expRepos []crunchyv1beta1.PGBackRestRepo
+	repos, _, _, err := reconcilePGBackRestRepos(
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expRepos, repos)
+}
+
+func TestReconcilePGBackRestReposAdd4thStorage_NoPVCRequired(t *testing.T) {
+	t.Parallel()
+	testEngineStorageSize, _ := resource.ParseQuantity("15G")
+	testEngineStorageClass := "someSC"
+	s3Repo1 := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket1",
+	}
+	s3Repo2 := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket2",
+	}
+	s3Repo3 := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket3",
+	}
+	s3Repo4 := &crunchyv1beta1.RepoS3{
+		Bucket: "bucket4",
+	}
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3:   s3Repo1,
+		},
+		{
+			Name: "repo2",
+			S3:   s3Repo2,
+		},
+		{
+			Name: "repo3",
+			S3:   s3Repo3,
+		},
+	}
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs1",
+			},
+		},
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs2",
+			},
+		},
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs3",
+			},
+		},
+		{
+			Spec: everestv1alpha1.DatabaseClusterBackupSpec{
+				BackupStorageName: "bs4",
+			},
+		},
+	}
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"bs1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket1",
+			},
+		},
+		"bs2": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket2",
+			},
+		},
+		"bs3": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket3",
+			},
+		},
+		"bs4": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:   "s3",
+				Bucket: "bucket4",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"bs1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+		"bs2": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+		"bs3": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+		"bs4": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testEngineStorage := everestv1alpha1.Storage{
+		Size:  testEngineStorageSize,
+		Class: &testEngineStorageClass,
+	}
+	expRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3:   s3Repo1,
+		},
+		{
+			Name: "repo2",
+			S3:   s3Repo2,
+		},
+		{
+			Name: "repo3",
+			S3:   s3Repo3,
+		},
+		{
+			Name: "repo4",
+			S3:   s3Repo4,
+		},
+	}
+
+	repos, _, _, _ := reconcilePGBackRestRepos( //nolint:dogsled
+		testRepos,
+		testBackupSchedules,
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
+	)
 	assert.Equal(t, expRepos, repos)
 }
 


### PR DESCRIPTION
**Remove pvc for new PG versions**
---
**Problem:**
EVEREST-1319

We keep the pvc repo if it was once created but we don’t create it anymore for the new clusters created by PG `2.7.0`+. 
We can live with this logic for the future versions without any additional maintenance needed, and then in v2 we could just get rid of the pvc repo completely if v2 won't support PG 2.6.0 (which requires a pvc repo) anymore. 
 
**Related pull requests**

- https://github.com/percona/everest/pull/1674

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
