### PR TITLE
EVEREST-2346 | PG on-demand backups are stuck in 'starting'

### DIFF
--- a/internal/controller/providers/pg/applier.go
+++ b/internal/controller/providers/pg/applier.go
@@ -1057,7 +1057,7 @@ func (p *applier) reconcilePGBackupsSpec() (pgv2.Backups, error) {
 	c := p.C
 	database := p.DB
 	engine := p.DBEngine
-	oldBackups := p.PerconaPGCluster.Spec.Backups
+	oldBackups := p.currentPGSpec.Backups
 
 	pgbackrestVersion, ok := engine.Status.AvailableVersions.Backup[database.Spec.Engine.Version]
 	if !ok {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-2346

PG on-demand backups are stuck in 'starting' state

**Cause:**

For the PG operator to trigger on-demand backups, it sets the `.spec.backups.pgbackrest.manual` field. However, the everest-operator appears to reset this field to its default value, preventing the backup from starting.

The underlying issue lies in how the everest-operator reconciles the `.spec.backups.pgbackrest.manual` field. Instead of reading the live PerconaPGCluster object to preserve the current state, it references the internally built PG object, which always has the default configuration.

Although this bug has existed for some time, it became apparent only after merging https://github.com/percona/everest-operator/pull/891, which exposed the incorrect reconciliation behavior.


**Solution:**

Use the live PG object to maintain the state of `.spec.backups.pgbackrest.manual` field

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
