### PR TITLE
EVEREST-2362 Fix setting owner reference in pg-restore resource

### DIFF
--- a/internal/controller/databaseclusterrestore_controller.go
+++ b/internal/controller/databaseclusterrestore_controller.go
@@ -491,14 +491,12 @@ func (r *DatabaseClusterRestoreReconciler) restorePG(ctx context.Context, restor
 			Namespace: restore.Namespace,
 		},
 	}
-	if err := controllerutil.SetControllerReference(restore, pgCR, r.Client.Scheme()); err != nil {
-		return err
-	}
+
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, pgCR, func() error {
 		pgCR.Spec.PGCluster = restore.Spec.DBClusterName
 		pgCR.Spec.RepoName = repoName
 		pgCR.Spec.Options, err = getPGRestoreOptions(restore.Spec.DataSource, backupBaseName)
-		return err
+		return controllerutil.SetControllerReference(restore, pgCR, r.Client.Scheme())
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-2362

*Short explanation of the problem.*
When user deletes PG restore resource from UI - it appears that only Everest part is deleted, the `pg-restore` is kept in K8S. After everest-operator restart - on startup it fetches `pg-restore` resource and tries to create an appropriate one `dbr`  but fails.

The main issue here is that `pg-restore` resource is kept when an appropriate `dbr` CR is deleted.

**Related pull requests**
everest PR: https://github.com/percona/everest/pull/1724

**Solution:**
Fix setting ownerReference for `pg-restore` resource
