### PR TITLE
EVEREST-XXX PG 2.8.2

### DIFF
--- a/internal/controller/everest/databaseclusterbackup_controller.go
+++ b/internal/controller/everest/databaseclusterbackup_controller.go
@@ -665,6 +665,13 @@ func (r *DatabaseClusterBackupReconciler) tryCreatePG(ctx context.Context, obj c
 		return err
 	}
 
+	// We want to ignore backups that are done to the hardcoded PVC-based repo1.
+	// This repo only exists to allow users to spin up a PG cluster without specifying a backup storage.
+	// Therefore, we don't want to allow users to restore from these backups so shouldn't create a DBB CR from repo1.
+	if pgBackup.Spec.RepoName == "repo1" && len(pg.Spec.Backups.PGBackRest.Repos) > 0 && pg.Spec.Backups.PGBackRest.Repos[0].Volume != nil {
+		return nil
+	}
+
 	storages := &everestv1alpha1.BackupStorageList{}
 	if err := r.List(ctx, storages, &client.ListOptions{}); err != nil {
 		// if no backup storages found - do nothing

--- a/internal/controller/everest/providers/pg/pg_repos_reconciler.go
+++ b/internal/controller/everest/providers/pg/pg_repos_reconciler.go
@@ -43,7 +43,7 @@ type pgReposReconciler struct {
 	reposToBeReconciled           *list.List
 }
 
-func newPGReposReconciler(oldRepos []crunchyv1beta1.PGBackRestRepo, backupSchedules []everestv1alpha1.BackupSchedule) (*pgReposReconciler, error) {
+func newPGReposReconciler(oldRepos []crunchyv1beta1.PGBackRestRepo, backupSchedules []everestv1alpha1.BackupSchedule, pvcRequired bool) (*pgReposReconciler, error) {
 	iniFile, err := ini.Load([]byte{})
 	if err != nil {
 		return nil, errors.New("failed to initialize PGBackrest secret data")
@@ -66,6 +66,9 @@ func newPGReposReconciler(oldRepos []crunchyv1beta1.PGBackRestRepo, backupSchedu
 	)
 
 	pgBackRestGlobal := make(map[string]string, maxPGBackrestOptionsNumber*maxStorages)
+	if pvcRequired {
+		pgBackRestGlobal["repo1-retention-full"] = "1"
+	}
 
 	return &pgReposReconciler{
 		pgBackRestGlobal:              pgBackRestGlobal,
@@ -75,8 +78,15 @@ func newPGReposReconciler(oldRepos []crunchyv1beta1.PGBackRestRepo, backupSchedu
 		reposReconciled:               list.New(),
 		backupSchedulesReconciled:     list.New(),
 		backupSchedulesToBeReconciled: backupSchedulesToBeReconciled,
-		availableRepoNames:            []string{"repo1", "repo2", "repo3", "repo4"},
+		availableRepoNames:            getAvailableRepoNames(pvcRequired),
 	}, nil
+}
+
+func getAvailableRepoNames(pvcRequired bool) []string {
+	if pvcRequired {
+		return []string{"repo2", "repo3", "repo4"} // repo1 is reserved for the PVC-based repo
+	}
+	return []string{"repo1", "repo2", "repo3", "repo4"}
 }
 
 func (p *pgReposReconciler) addRepoToPGGlobal(
@@ -392,8 +402,36 @@ func (p *pgReposReconciler) pgBackRestIniBytes() ([]byte, error) {
 	return pgBackrestSecretBuf.Bytes(), nil
 }
 
-func (p *pgReposReconciler) sortRepos() ([]crunchyv1beta1.PGBackRestRepo, error) {
+func (p *pgReposReconciler) addDefaultRepo(engineStorage everestv1alpha1.Storage, pvcRequired bool) ([]crunchyv1beta1.PGBackRestRepo, error) {
 	var newRepos []crunchyv1beta1.PGBackRestRepo
+
+	// The PG operator requires a repo to be set up in order to create
+	// replicas. Without any credentials we can't set a cloud-based repo so we
+	// define a PVC-backed repo in case the user doesn't define any cloud-based
+	// repos. Moreover, we need to keep this repo in the list even if the user
+	// defines a cloud-based repo because the PG operator will restart the
+	// cluster if the only repo in the list is changed.
+	if pvcRequired {
+		newRepos = []crunchyv1beta1.PGBackRestRepo{
+			{
+				Name: "repo1",
+				Volume: &crunchyv1beta1.RepoPVC{
+					VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						StorageClassName: engineStorage.Class,
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: engineStorage.Size,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
 	// Add the reconciled repos to the list of repos
 	for e := p.reposReconciled.Front(); e != nil; e = e.Next() {
 		repo, ok := e.Value.(crunchyv1beta1.PGBackRestRepo)


### PR DESCRIPTION
**PG 2.8.2**
---
**Problem:**
EVEREST-0

PG 2.8.2 allows to upgrade from PG 2.7.0, that's why we replace 2.8.0 to 2.8.2. 
Same as in PG 2.8.0, there is the following specificity:
- for clusters created with 2.8.2 there is no default pvc storage created. If there was no schedule configured during the cluster creation time, it's expected that the cluster will shortly go into the initializing state once we add the fist storage (create a schedule, take a personal backup). It is also expected that the initial backup is visible on the UI since the backup was taken to a listed backup storage. 
- when there was no storages and we first take a scheduled backup it might fail bc of the timing - the repo might not have been initialized properly. However the initial backup (which is now visible on the UI) will succeed, and the following backups will succeed as well, so this issue is considered as minor.
- for the old clusters created with 2.7.0 and below, the pvc storage repo is kept to support DB creation when users have updated Everest but did not yet update the PG operator version. 

**Related pull requests**
- https://github.com/percona/everest/pull/1743
- https://github.com/percona/everest-catalog/pull/72

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
