### PR TITLE
Support go-templating for dynamic value injection in lbc

### DIFF
--- a/internal/controller/everest/common/helper.go
+++ b/internal/controller/everest/common/helper.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"text/template"
 
 	"github.com/AlekSi/pointer"
 	crunchyv1beta1 "github.com/percona/percona-postgresql-operator/v2/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
@@ -677,6 +678,23 @@ func GetLoadBalancerConfig(
 	return lbc, nil
 }
 
+// SetTemplateValues sets the respective values in the template
+func SetTemplateValues(value string, database *everestv1alpha1.DatabaseCluster) (string, error) {
+	tmpl, err := template.New("").Parse(value)
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+
+	err = tmpl.Execute(&buf, database)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
 // GetAnnotations returns annotations from the LoadBalancerConfig used in the given DB.
 func GetAnnotations(
 	ctx context.Context,
@@ -692,7 +710,22 @@ func GetAnnotations(
 		return nil, err
 	}
 
-	return lbc.Spec.Annotations, nil
+	annotations := lbc.Spec.Annotations
+
+	for key, value := range annotations {
+		// check for labels with Golang Tenplates
+		if strings.Contains(value, "{{") && strings.Contains(value, "}}") {
+
+			updatedVal, err := SetTemplateValues(value, database)
+			if err != nil {
+				return map[string]string{}, err
+			}
+
+			annotations[key] = updatedVal
+		}
+	}
+
+	return annotations, nil
 }
 
 // GetPodSchedulingPolicy returns the PodSchedulingPolicy object by name.

--- a/internal/controller/everest/common/helper_test.go
+++ b/internal/controller/everest/common/helper_test.go
@@ -495,3 +495,93 @@ func TestVerifyPVCResizeFailure(t *testing.T) {
 		})
 	}
 }
+
+func TestSetTemplateValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Name        string
+		Template    string
+		Database    *everestv1alpha1.DatabaseCluster
+		Expected    string
+		ExpectError bool
+	}{
+		{
+			Name:        "Improper template",
+			Template:    "{{ .ObjectMeta.Name }-example.org",
+			Database:    &everestv1alpha1.DatabaseCluster{},
+			Expected:    "",
+			ExpectError: true,
+		},
+		{
+			Name:     "Valid template with database name",
+			Template: "{{ .ObjectMeta.Name }}-example.org",
+			Database: &everestv1alpha1.DatabaseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-name",
+				},
+			},
+			Expected:    "test-name-example.org",
+			ExpectError: false,
+		},
+		{
+			Name:     "Valid template with database name and namespace",
+			Template: "{{ .ObjectMeta.Name }}-{{ .ObjectMeta.Namespace }}-example.org",
+			Database: &everestv1alpha1.DatabaseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-name",
+					Namespace: "test-ns",
+				},
+			},
+			Expected:    "test-name-test-ns-example.org",
+			ExpectError: false,
+		},
+		{
+			Name:     "Valid template with database name, namespace and engine version",
+			Template: "{{ .ObjectMeta.Name }}-{{ .ObjectMeta.Namespace }}-{{ .Spec.Engine.Version }}-example.org",
+			Database: &everestv1alpha1.DatabaseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-name",
+					Namespace: "test-ns",
+				},
+				Spec: everestv1alpha1.DatabaseClusterSpec{
+					Engine: everestv1alpha1.Engine{
+						Version: "v0.0.1",
+					},
+				},
+			},
+			Expected:    "test-name-test-ns-v0.0.1-example.org",
+			ExpectError: false,
+		},
+		{
+			Name:     "Valid template with database name and engine version",
+			Template: "{{ .ObjectMeta.Name }}-{{ .Spec.Engine.Version }}-example.org",
+			Database: &everestv1alpha1.DatabaseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-name",
+				},
+				Spec: everestv1alpha1.DatabaseClusterSpec{
+					Engine: everestv1alpha1.Engine{
+						Version: "v0.0.2",
+					},
+				},
+			},
+			Expected:    "test-name-v0.0.2-example.org",
+			ExpectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := SetTemplateValues(tc.Template, tc.Database)
+			if tc.ExpectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.Expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-1817

<!--*Short explanation of the problem.*-->

Support Go templating in LoadBalancerConfig annotations for dynamic value injection.
Fixes: https://github.com/openeverest/openeverest/issues/1817

**Related pull requests**

- N/A

**Cause:**
<!--*Short explanation of the root cause of the issue if applicable.*-->

**Solution:**
<!--*Short explanation of the solution we are providing with this PR.*-->
The openeverest-operator currently uses a [helper function](https://github.com/openeverest/openeverest-operator/blob/741cc0387bdd3f3d46ad561a5a35af1dd68b4e60/internal/controller/everest/common/helper.go#L681-L696) to fetch annotations. This logic should be updated to:

1. Iterate over the annotations defined in the LBC.
2. Check if the value contains template syntax.
3. Execute the template passing the relevant `DatabaseCluster` struct.
4. Apply the resolved string as the final annotation value.

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [ ] Is the Jira ticket created and referenced properly?

**Tests**
- [ ] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
