### PR TITLE
fix(pg): map DatabaseCluster proxy.config to PerconaPgCluster pgBouncer.config

### DIFF
--- a/internal/controller/everest/providers/pg/applier.go
+++ b/internal/controller/everest/providers/pg/applier.go
@@ -252,6 +252,15 @@ func (p *applier) Proxy() error {
 		pg.Spec.Proxy.PGBouncer.Resources.Limits[corev1.ResourceMemory] = database.Spec.Proxy.Resources.Memory
 	}
 	pg.Spec.Proxy.PGBouncer.ExposeSuperusers = true
+
+	if database.Spec.Proxy.Config != "" {
+		cfg, err := ParsePGBouncerConfig(database.Spec.Proxy.Config)
+		if err != nil {
+			return fmt.Errorf("proxy config: %w", err)
+		}
+		pg.Spec.Proxy.PGBouncer.Config = cfg
+	}
+
 	pg.Spec.Users = []crunchyv1beta1.PostgresUserSpec{
 		{
 			Name:       "postgres",

--- a/internal/controller/everest/providers/pg/pgbouncer_config.go
+++ b/internal/controller/everest/providers/pg/pgbouncer_config.go
@@ -1,0 +1,68 @@
+// everest-operator
+// Copyright (C) 2022 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pg
+
+import (
+	"fmt"
+	"strings"
+
+	crunchyv1beta1 "github.com/percona/percona-postgresql-operator/v2/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// rawPGBouncerConfig is the YAML structure for DatabaseCluster.spec.proxy.config.
+// Supports top-level keys: global, databases, users.
+// See https://www.pgbouncer.org/config.html
+type rawPGBouncerConfig struct {
+	Global    map[string]interface{} `yaml:"global"`
+	Databases map[string]interface{} `yaml:"databases"`
+	Users     map[string]interface{} `yaml:"users"`
+}
+
+// ParsePGBouncerConfig parses the proxy config YAML string from DatabaseCluster.spec.proxy.config
+// into a PGBouncerConfiguration. Empty or whitespace-only config returns an empty config.
+func ParsePGBouncerConfig(configYAML string) (crunchyv1beta1.PGBouncerConfiguration, error) {
+	out := crunchyv1beta1.PGBouncerConfiguration{}
+	s := strings.TrimSpace(configYAML)
+	if s == "" {
+		return out, nil
+	}
+
+	var raw rawPGBouncerConfig
+	if err := yaml.Unmarshal([]byte(s), &raw); err != nil {
+		return out, fmt.Errorf("parse pgBouncer config YAML: %w", err)
+	}
+
+	out.Global = toStringMap(raw.Global)
+	out.Databases = toStringMap(raw.Databases)
+	out.Users = toStringMap(raw.Users)
+	return out, nil
+}
+
+func toStringMap(m map[string]interface{}) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		if v == nil {
+			out[k] = ""
+			continue
+		}
+		out[k] = fmt.Sprint(v)
+	}
+	return out
+}

--- a/internal/controller/everest/providers/pg/pgbouncer_config_test.go
+++ b/internal/controller/everest/providers/pg/pgbouncer_config_test.go
@@ -1,0 +1,102 @@
+package pg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePGBouncerConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		check   func(*testing.T, *struct{ Global, Databases, Users map[string]string })
+		wantErr bool
+	}{
+		{
+			name: "empty",
+			yaml: "",
+			check: func(t *testing.T, c *struct {
+				Global    map[string]string
+				Databases map[string]string
+				Users     map[string]string
+			}) {
+				assert.Nil(t, c.Global)
+				assert.Nil(t, c.Databases)
+				assert.Nil(t, c.Users)
+			},
+		},
+		{
+			name: "whitespace only",
+			yaml: "  \n\t  ",
+			check: func(t *testing.T, c *struct {
+				Global    map[string]string
+				Databases map[string]string
+				Users     map[string]string
+			}) {
+				assert.Nil(t, c.Global)
+			},
+		},
+		{
+			name: "global only",
+			yaml: `
+global:
+  client_tls_sslmode: allow
+  default_pool_size: "150"
+  max_client_conn: "300"
+`,
+			check: func(t *testing.T, c *struct {
+				Global    map[string]string
+				Databases map[string]string
+				Users     map[string]string
+			}) {
+				require.NotNil(t, c.Global)
+				assert.Equal(t, "allow", c.Global["client_tls_sslmode"])
+				assert.Equal(t, "150", c.Global["default_pool_size"])
+				assert.Equal(t, "300", c.Global["max_client_conn"])
+				assert.Nil(t, c.Databases)
+				assert.Nil(t, c.Users)
+			},
+		},
+		{
+			name: "global with numeric values",
+			yaml: `
+global:
+  default_pool_size: 150
+  max_client_conn: 300
+`,
+			check: func(t *testing.T, c *struct {
+				Global    map[string]string
+				Databases map[string]string
+				Users     map[string]string
+			}) {
+				require.NotNil(t, c.Global)
+				assert.Equal(t, "150", c.Global["default_pool_size"])
+				assert.Equal(t, "300", c.Global["max_client_conn"])
+			},
+		},
+		{
+			name:    "invalid YAML",
+			yaml:    "global:\n  [",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePGBouncerConfig(tt.yaml)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, &struct {
+					Global    map[string]string
+					Databases map[string]string
+					Users     map[string]string
+				}{got.Global, got.Databases, got.Users})
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`DatabaseCluster.spec.proxy.config` was not being propagated to `PerconaPgCluster.spec.proxy.pgBouncer.config`, so custom pgBouncer settings (e.g. `default_pool_size`, `max_client_conn`, `client_tls_sslmode`) were lost during reconciliation.

## Changes

- **`pgbouncer_config.go`**: Add `ParsePGBouncerConfig` to parse `spec.proxy.config` YAML into `PGBouncerConfiguration` (`global`, `databases`, `users`).
- **`applier.go`**: In `Proxy()`, set `pg.Spec.Proxy.PGBouncer.Config` when `database.Spec.Proxy.Config` is non-empty.
- **`pgbouncer_config_test.go`**: Unit tests for the parser (empty, whitespace, global section, numeric values, invalid YAML).

## Example

```yaml
spec:
  proxy:
    type: pgbouncer
    config: |
      global:
        client_tls_sslmode: allow
        default_pool_size: "150"
        max_client_conn: "300"
```

This config is now correctly applied to the underlying PerconaPgCluster.

## Testing

- `go test ./internal/controller/everest/providers/pg/...` — all pass
- `go build ./...` — succeeds

Fixes https://github.com/openeverest/openeverest/issues/1823