### PR TITLE
Ensure PG restore deletion before database cleanup

### DIFF
--- a/internal/controller/everest/common/helper.go
+++ b/internal/controller/everest/common/helper.go
@@ -834,6 +834,36 @@ func DeleteBackupsForDatabase(
 	return false, nil
 }
 
+// DeleteRestoresForDatabase deletes all DatabaseClusterRestores for the given database.
+// Returns true if no restores remain.
+func DeleteRestoresForDatabase(
+	ctx context.Context,
+	c client.Client,
+	dbName, dbNs string,
+) (bool, error) {
+	restoreList, err := DatabaseClusterRestoresThatReferenceObject(ctx, c, consts.DBClusterRestoreDBClusterNameField, dbNs, dbName)
+	if err != nil {
+		return false, err
+	}
+	if len(restoreList.Items) == 0 {
+		return true, nil
+	}
+	for _, restore := range restoreList.Items {
+		if !restore.GetDeletionTimestamp().IsZero() {
+			// Already deleting, continue to next.
+			continue
+		}
+		if controllerutil.ContainsFinalizer(&restore, everestv1alpha1.InUseResourceFinalizer) {
+			// Restore is in use, wait for it to be released.
+			continue
+		}
+		if err := c.Delete(ctx, &restore); err != nil {
+			return false, err
+		}
+	}
+	return false, nil
+}
+
 // HandleUpstreamClusterCleanup handles the cleanup of the upstream cluster objects.
 // Returns true if cleanup is complete.
 func HandleUpstreamClusterCleanup(

--- a/internal/controller/everest/providers/pg/provider.go
+++ b/internal/controller/everest/providers/pg/provider.go
@@ -296,6 +296,12 @@ func handleDBBackupsCleanup(
 			return false, nil
 		}
 
+		if done, err := common.DeleteRestoresForDatabase(ctx, c, database.GetName(), database.GetNamespace()); err != nil {
+			return false, err
+		} else if !done {
+			return false, nil
+		}
+
 		// Wait for the backup controller to fully finish reconciling deleted backups
 		// before deleting the cluster.
 		//

--- a/internal/controller/everest/providers/pxc/applier.go
+++ b/internal/controller/everest/providers/pxc/applier.go
@@ -149,7 +149,6 @@ func configureProxySQLStorage(
 	current *pxcv1.PerconaXtraDBClusterSpec,
 	db *everestv1alpha1.DatabaseCluster,
 ) error {
-
 	getCurrentProxySQLStorageSize := func() resource.Quantity {
 		if db.Status.Status == everestv1alpha1.AppStateNew ||
 			current == nil ||


### PR DESCRIPTION
#949 ensured that the PG backups are deleted before the DB by re-introducing the handling of the `DBBackupCleanupFinalizer`. This PR does the same for restores, otherwise the PG Operator fails to delete the PG restore objects if the PG cluster is not longer around.