### PR TITLE
feat(pg): reconcile spec.proxy.config into pgBouncer configuration

### DIFF
--- a/internal/controller/everest/providers/pg/applier.go
+++ b/internal/controller/everest/providers/pg/applier.go
@@ -251,6 +251,15 @@ func (p *applier) Proxy() error {
 	if !database.Spec.Proxy.Resources.Memory.IsZero() {
 		pg.Spec.Proxy.PGBouncer.Resources.Limits[corev1.ResourceMemory] = database.Spec.Proxy.Resources.Memory
 	}
+
+	if database.Spec.Proxy.Config != "" {
+		cfg, err := ParsePgBouncerConfig(database.Spec.Proxy.Config)
+		if err != nil {
+			return fmt.Errorf("invalid proxy config: %w", err)
+		}
+		pg.Spec.Proxy.PGBouncer.Config = cfg
+	}
+
 	pg.Spec.Proxy.PGBouncer.ExposeSuperusers = true
 	pg.Spec.Users = []crunchyv1beta1.PostgresUserSpec{
 		{

--- a/internal/controller/everest/providers/pg/pg_config.go
+++ b/internal/controller/everest/providers/pg/pg_config.go
@@ -24,6 +24,13 @@ import (
 	"strings"
 
 	"github.com/go-ini/ini"
+	crunchyv1beta1 "github.com/percona/percona-postgresql-operator/v2/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
+)
+
+const (
+	pgBouncerSectionGlobal    = "pgbouncer"
+	pgBouncerSectionDatabases = "databases"
+	pgBouncerSectionUsers     = "users"
 )
 
 // ConfigParser represents a parser for PG config.
@@ -81,6 +88,86 @@ func (p *ConfigParser) newParser(line []byte) (*ini.File, error) {
 	return ini.LoadSources(ini.LoadOptions{
 		KeyValueDelimiters: delims,
 	}, line)
+}
+
+// ParsePgBouncerConfig parses a free-form pgbouncer.ini string into the
+// upstream crunchyv1beta1.PGBouncerConfiguration struct.
+//
+// The input is expected to use the standard pgbouncer.ini sections:
+//
+//	[pgbouncer]   -> mapped to Global
+//	[databases]   -> mapped to Databases
+//	[users]       -> mapped to Users
+//
+// Keys outside any section (i.e. flat `key = value` lines without a section
+// header) are treated as if they belonged to the [pgbouncer] section, so users
+// can paste a minimal snippet without a header. Unknown sections result in an
+// error so users get fast feedback.
+//
+// Duplicate keys within a section are resolved by last-one-wins (the default
+// behavior of the underlying ini parser).
+//
+// An empty input returns a zero-value struct without error (no-op).
+func ParsePgBouncerConfig(config string) (crunchyv1beta1.PGBouncerConfiguration, error) {
+	out := crunchyv1beta1.PGBouncerConfiguration{}
+	if strings.TrimSpace(config) == "" {
+		return out, nil
+	}
+
+	f, err := ini.LoadSources(ini.LoadOptions{
+		IgnoreInlineComment: false,
+	}, []byte(config))
+	if err != nil {
+		return crunchyv1beta1.PGBouncerConfiguration{}, fmt.Errorf("failed to parse pgbouncer config: %w", err)
+	}
+
+	for _, name := range f.SectionStrings() {
+		sec := f.Section(name)
+		// Treat the default (unnamed) section as [pgbouncer] so users can
+		// paste flat key=value lines without a section header.
+		effective := strings.ToLower(name)
+		if name == ini.DefaultSection {
+			effective = pgBouncerSectionGlobal
+		}
+
+		switch effective {
+		case pgBouncerSectionGlobal:
+			if len(sec.Keys()) == 0 {
+				continue
+			}
+			if out.Global == nil {
+				out.Global = make(map[string]string)
+			}
+			for k, v := range sec.KeysHash() {
+				out.Global[k] = v
+			}
+		case pgBouncerSectionDatabases:
+			if len(sec.Keys()) == 0 {
+				continue
+			}
+			if out.Databases == nil {
+				out.Databases = make(map[string]string)
+			}
+			for k, v := range sec.KeysHash() {
+				out.Databases[k] = v
+			}
+		case pgBouncerSectionUsers:
+			if len(sec.Keys()) == 0 {
+				continue
+			}
+			if out.Users == nil {
+				out.Users = make(map[string]string)
+			}
+			for k, v := range sec.KeysHash() {
+				out.Users[k] = v
+			}
+		default:
+			return crunchyv1beta1.PGBouncerConfiguration{}, fmt.Errorf(
+				"unknown pgbouncer config section %q: expected one of [pgbouncer], [databases], [users]", name)
+		}
+	}
+
+	return out, nil
 }
 
 // PG config supports the following two formats per config line:

--- a/internal/controller/everest/providers/pg/pg_test.go
+++ b/internal/controller/everest/providers/pg/pg_test.go
@@ -218,6 +218,134 @@ func TestConfigParser_lineUsesEqualSign(t *testing.T) {
 	}
 }
 
+func TestParsePgBouncerConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  string
+		want    crunchyv1beta1.PGBouncerConfiguration
+		wantErr bool
+	}{
+		{
+			name:   "empty input returns zero value",
+			config: "",
+			want:   crunchyv1beta1.PGBouncerConfiguration{},
+		},
+		{
+			name:   "whitespace only input returns zero value",
+			config: "  \n\n\t\n",
+			want:   crunchyv1beta1.PGBouncerConfiguration{},
+		},
+		{
+			name: "flat input (no section header) is treated as [pgbouncer]",
+			config: `
+pool_mode = transaction
+max_client_conn = 1000
+`,
+			want: crunchyv1beta1.PGBouncerConfiguration{
+				Global: map[string]string{
+					"pool_mode":       "transaction",
+					"max_client_conn": "1000",
+				},
+			},
+		},
+		{
+			name: "all three sections populated",
+			config: `
+[pgbouncer]
+pool_mode = transaction
+max_client_conn = 1000
+
+[databases]
+myapp = host=primary-pg port=5432
+
+[users]
+pgbouncer = pool_mode=session
+`,
+			want: crunchyv1beta1.PGBouncerConfiguration{
+				Global: map[string]string{
+					"pool_mode":       "transaction",
+					"max_client_conn": "1000",
+				},
+				Databases: map[string]string{
+					"myapp": "host=primary-pg port=5432",
+				},
+				Users: map[string]string{
+					"pgbouncer": "pool_mode=session",
+				},
+			},
+		},
+		{
+			name: "unknown section returns error",
+			config: `
+[pgbouncer]
+pool_mode = transaction
+
+[bogus]
+foo = bar
+`,
+			wantErr: true,
+		},
+		{
+			name: "duplicate keys within a section: last one wins",
+			config: `
+[pgbouncer]
+pool_mode = session
+pool_mode = transaction
+`,
+			want: crunchyv1beta1.PGBouncerConfiguration{
+				Global: map[string]string{
+					"pool_mode": "transaction",
+				},
+			},
+		},
+		{
+			name:    "malformed line returns error",
+			config:  "this is not a valid ini line",
+			wantErr: true,
+		},
+		{
+			name: "section names are case-insensitive",
+			config: `
+[PGBouncer]
+pool_mode = transaction
+
+[Databases]
+myapp = host=primary-pg
+
+[Users]
+admin = pool_mode=session
+`,
+			want: crunchyv1beta1.PGBouncerConfiguration{
+				Global: map[string]string{
+					"pool_mode": "transaction",
+				},
+				Databases: map[string]string{
+					"myapp": "host=primary-pg",
+				},
+				Users: map[string]string{
+					"admin": "pool_mode=session",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParsePgBouncerConfig(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestReconcilePGBackRestReposEmptyAddRequest(t *testing.T) {
 	t.Parallel()
 	testRepos := []crunchyv1beta1.PGBackRestRepo{}

--- a/test/integration/core/pg/21-assert.yaml
+++ b/test/integration/core/pg/21-assert.yaml
@@ -27,3 +27,56 @@ assertAll:
 
   - celExpr: "pg.spec.proxy.pgBouncer.config.users['pgbouncer'] == 'pool_mode=session'"
     message: "pgBouncer.config.users.pgbouncer is not set correctly"
+---
+apiVersion: everest.percona.com/v1alpha1
+kind: DatabaseCluster
+metadata:
+  name: test-pg-cluster
+spec:
+  backup:
+    pitr:
+      enabled: false
+  engine:
+    replicas: 3
+    resources:
+      cpu: "1"
+      memory: 2G
+    storage:
+      size: 25Gi
+    type: postgresql
+  proxy:
+    expose:
+      type: internal
+    replicas: 3
+    resources:
+      cpu: "1"
+      memory: 30M
+    type: pgbouncer
+    config: |
+      [pgbouncer]
+      pool_mode = transaction
+      max_client_conn = 1000
+
+      [databases]
+      myapp = host=primary-pg port=5432
+
+      [users]
+      pgbouncer = pool_mode=session
+status:
+  status: ready
+---
+apiVersion: pgv2.percona.com/v2
+kind: PerconaPGCluster
+metadata:
+  name: test-pg-cluster
+spec:
+  proxy:
+    pgBouncer:
+      config:
+        global:
+          pool_mode: transaction
+          max_client_conn: "1000"
+        databases:
+          myapp: host=primary-pg port=5432
+        users:
+          pgbouncer: pool_mode=session

--- a/test/integration/core/pg/21-assert.yaml
+++ b/test/integration/core/pg/21-assert.yaml
@@ -1,0 +1,29 @@
+apiVersion: kuttl.dev/v1
+kind: TestAssert
+timeout: 30
+collectors:
+  - command: kubectl get dbc/test-pg-cluster -n ${NAMESPACE} -o yaml
+  - command: kubectl get perconapgcluster/test-pg-cluster -n ${NAMESPACE} -o yaml
+
+  - command: kubectl get deploy/everest-controller-manager -n everest-system -o yaml
+  - type: pod
+    namespace: everest-system
+    selector: control-plane=controller-manager
+    tail: 100
+resourceRefs:
+  - apiVersion: pgv2.percona.com/v2
+    kind: PerconaPGCluster
+    name: test-pg-cluster
+    ref: pg
+assertAll:
+  - celExpr: "pg.spec.proxy.pgBouncer.config.global['pool_mode'] == 'transaction'"
+    message: "pgBouncer.config.global.pool_mode is not 'transaction'"
+
+  - celExpr: "pg.spec.proxy.pgBouncer.config.global['max_client_conn'] == '1000'"
+    message: "pgBouncer.config.global.max_client_conn is not '1000'"
+
+  - celExpr: "pg.spec.proxy.pgBouncer.config.databases['myapp'] == 'host=primary-pg port=5432'"
+    message: "pgBouncer.config.databases.myapp is not set correctly"
+
+  - celExpr: "pg.spec.proxy.pgBouncer.config.users['pgbouncer'] == 'pool_mode=session'"
+    message: "pgBouncer.config.users.pgbouncer is not set correctly"

--- a/test/integration/core/pg/21-assert.yaml
+++ b/test/integration/core/pg/21-assert.yaml
@@ -10,23 +10,6 @@ collectors:
     namespace: everest-system
     selector: control-plane=controller-manager
     tail: 100
-resourceRefs:
-  - apiVersion: pgv2.percona.com/v2
-    kind: PerconaPGCluster
-    name: test-pg-cluster
-    ref: pg
-assertAll:
-  - celExpr: "pg.spec.proxy.pgBouncer.config.global['pool_mode'] == 'transaction'"
-    message: "pgBouncer.config.global.pool_mode is not 'transaction'"
-
-  - celExpr: "pg.spec.proxy.pgBouncer.config.global['max_client_conn'] == '1000'"
-    message: "pgBouncer.config.global.max_client_conn is not '1000'"
-
-  - celExpr: "pg.spec.proxy.pgBouncer.config.databases['myapp'] == 'host=primary-pg port=5432'"
-    message: "pgBouncer.config.databases.myapp is not set correctly"
-
-  - celExpr: "pg.spec.proxy.pgBouncer.config.users['pgbouncer'] == 'pool_mode=session'"
-    message: "pgBouncer.config.users.pgbouncer is not set correctly"
 ---
 apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseCluster

--- a/test/integration/core/pg/21-set-proxy-config.yaml
+++ b/test/integration/core/pg/21-set-proxy-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+timeout: 10
+---
+apiVersion: everest.percona.com/v1alpha1
+kind: DatabaseCluster
+metadata:
+  name: test-pg-cluster
+spec:
+  engine:
+    replicas: 3
+    type: postgresql
+  proxy:
+    replicas: 3
+    type: pgbouncer
+    config: |
+      [pgbouncer]
+      pool_mode = transaction
+      max_client_conn = 1000
+
+      [databases]
+      myapp = host=primary-pg port=5432
+
+      [users]
+      pgbouncer = pool_mode=session

--- a/test/integration/core/pg/22-assert.yaml
+++ b/test/integration/core/pg/22-assert.yaml
@@ -24,3 +24,39 @@ assertAll:
 
   - celExpr: "!has(pg.spec.proxy.pgBouncer.config.users)"
     message: "pgBouncer.config.users was not cleared"
+---
+apiVersion: everest.percona.com/v1alpha1
+kind: DatabaseCluster
+metadata:
+  name: test-pg-cluster
+spec:
+  backup:
+    pitr:
+      enabled: false
+  engine:
+    replicas: 3
+    resources:
+      cpu: "1"
+      memory: 2G
+    storage:
+      size: 25Gi
+    type: postgresql
+  proxy:
+    expose:
+      type: internal
+    replicas: 3
+    resources:
+      cpu: "1"
+      memory: 30M
+    type: pgbouncer
+status:
+  status: ready
+---
+apiVersion: pgv2.percona.com/v2
+kind: PerconaPGCluster
+metadata:
+  name: test-pg-cluster
+spec:
+  proxy:
+    pgBouncer:
+      config: {}

--- a/test/integration/core/pg/22-assert.yaml
+++ b/test/integration/core/pg/22-assert.yaml
@@ -1,0 +1,26 @@
+apiVersion: kuttl.dev/v1
+kind: TestAssert
+timeout: 30
+collectors:
+  - command: kubectl get dbc/test-pg-cluster -n ${NAMESPACE} -o yaml
+  - command: kubectl get perconapgcluster/test-pg-cluster -n ${NAMESPACE} -o yaml
+
+  - command: kubectl get deploy/everest-controller-manager -n everest-system -o yaml
+  - type: pod
+    namespace: everest-system
+    selector: control-plane=controller-manager
+    tail: 100
+resourceRefs:
+  - apiVersion: pgv2.percona.com/v2
+    kind: PerconaPGCluster
+    name: test-pg-cluster
+    ref: pg
+assertAll:
+  - celExpr: "!has(pg.spec.proxy.pgBouncer.config.global)"
+    message: "pgBouncer.config.global was not cleared"
+
+  - celExpr: "!has(pg.spec.proxy.pgBouncer.config.databases)"
+    message: "pgBouncer.config.databases was not cleared"
+
+  - celExpr: "!has(pg.spec.proxy.pgBouncer.config.users)"
+    message: "pgBouncer.config.users was not cleared"

--- a/test/integration/core/pg/22-assert.yaml
+++ b/test/integration/core/pg/22-assert.yaml
@@ -10,20 +10,6 @@ collectors:
     namespace: everest-system
     selector: control-plane=controller-manager
     tail: 100
-resourceRefs:
-  - apiVersion: pgv2.percona.com/v2
-    kind: PerconaPGCluster
-    name: test-pg-cluster
-    ref: pg
-assertAll:
-  - celExpr: "!has(pg.spec.proxy.pgBouncer.config.global)"
-    message: "pgBouncer.config.global was not cleared"
-
-  - celExpr: "!has(pg.spec.proxy.pgBouncer.config.databases)"
-    message: "pgBouncer.config.databases was not cleared"
-
-  - celExpr: "!has(pg.spec.proxy.pgBouncer.config.users)"
-    message: "pgBouncer.config.users was not cleared"
 ---
 apiVersion: everest.percona.com/v1alpha1
 kind: DatabaseCluster

--- a/test/integration/core/pg/22-clear-proxy-config.yaml
+++ b/test/integration/core/pg/22-clear-proxy-config.yaml
@@ -1,5 +1,16 @@
 apiVersion: kuttl.dev/v1
 kind: TestStep
 timeout: 10
-commands:
-  - command: kubectl patch db/test-pg-cluster -n $NAMESPACE --type=json -p='[{"op":"remove","path":"/spec/proxy/config"}]'
+---
+apiVersion: everest.percona.com/v1alpha1
+kind: DatabaseCluster
+metadata:
+  name: test-pg-cluster
+spec:
+  engine:
+    replicas: 3
+    type: postgresql
+  proxy:
+    replicas: 3
+    type: pgbouncer
+    config: ""

--- a/test/integration/core/pg/22-clear-proxy-config.yaml
+++ b/test/integration/core/pg/22-clear-proxy-config.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1
+kind: TestStep
+timeout: 10
+commands:
+  - command: kubectl patch db/test-pg-cluster -n $NAMESPACE --type=json -p='[{"op":"remove","path":"/spec/proxy/config"}]'


### PR DESCRIPTION
fixes [#2095 ](https://github.com/openeverest/openeverest/issues/2095)

Parse a free-form pgbouncer.ini string from `DatabaseCluster.spec.proxy.config` into the upstream `crunchyv1beta1.PGBouncerConfiguration` struct (Global, Databases, Users) and assign it to `PerconaPGCluster.spec.proxy.pgBouncer.config` during `Proxy()` reconcile.

Closes openeverest/openeverest#2095

**CHANGE DESCRIPTION**
---
**Problem:**
EVEREST-0

`spec.proxy.config` is silently ignored for PG, there's no way to tune pgBouncer from a `DatabaseCluster`.

**Related pull requests**

- N/A

**Cause:**
The PG provider's `Proxy()` never reads `database.Spec.Proxy.Config`, so the field never reaches `PerconaPGCluster.spec.proxy.pgBouncer.config`.

**Solution:**
Added `ParsePgBouncerConfig` that turns a pgbouncer.ini string into the upstream struct (`[pgbouncer]`→Global, `[databases]`→Databases, `[users]`→Users; headerless input is treated as `[pgbouncer]`; unknown sections error out). Wired it into `Proxy()` so the parsed value lands on the upstream CR, with parse errors surfaced as `invalid proxy config: …`.

**CHECKLIST**
---
**Helm chart**
- [ ] N/A 

**Jira**
- [ ] N/A 

**Tests**
- [x] Integration test added under `test/integration/core/pg/` (`21-*` sets the config and asserts all three maps land on the upstream CR via `celExpr`; `22-*` removes the field and asserts the maps are cleared).
- [x] Table-driven unit tests for `ParsePgBouncerConfig` covering empty input, headerless input, all three sections, unknown section, duplicate-key last-wins, malformed line, case-insensitive sections.
