### PR TITLE
use pgBackRest global storage settings

### DIFF
--- a/internal/controller/everest/providers/pg/applier.go
+++ b/internal/controller/everest/providers/pg/applier.go
@@ -817,7 +817,7 @@ func getPGRestoreOptions(
 	if pointer.Get(backupStorage.Spec.ForcePathStyle) {
 		options = append(options, "--"+fmt.Sprintf(pgBackRestStorageForcePathTmpl, repoName)+"="+pgBackRestStoragePathStyle)
 	}
-	if !pointer.Get(backupStorage.Spec.VerifyTLS) {
+	if backupStorage.Spec.VerifyTLS != nil && !*backupStorage.Spec.VerifyTLS {
 		options = append(options, "--no-"+fmt.Sprintf(pgBackRestStorageVerifyTmpl, repoName))
 	}
 

--- a/internal/controller/everest/providers/pg/pg_repos_reconciler.go
+++ b/internal/controller/everest/providers/pg/pg_repos_reconciler.go
@@ -100,11 +100,11 @@ func (p *pgReposReconciler) addRepoToPGGlobal(
 	if retentionCopies != nil {
 		p.pgBackRestGlobal[fmt.Sprintf(pgBackRestRetentionTmpl, repoName)] = strconv.Itoa(getPGRetentionCopies(*retentionCopies))
 	}
-	if verify := pointer.Get(verifyTLS); !verify {
+	if verifyTLS != nil && !*verifyTLS {
 		// See: https://pgbackrest.org/configuration.html#section-repository/option-repo-storage-verify-tls
 		p.pgBackRestGlobal[fmt.Sprintf(pgBackRestStorageVerifyTmpl, repoName)] = "n"
 	}
-	if forceStyle := pointer.Get(forcePathStyle); !forceStyle {
+	if forceStyle := pointer.Get(forcePathStyle); forceStyle {
 		// See: https://pgbackrest.org/configuration.html#section-repository/option-repo-s3-uri-style
 		p.pgBackRestGlobal[fmt.Sprintf(pgBackRestStorageForcePathTmpl, repoName)] = pgBackRestStoragePathStyle
 	}
@@ -193,7 +193,7 @@ func (p *pgReposReconciler) reconcileBackups(
 		// Keep track of backup storages which are already in use by a repo
 		p.backupStoragesInRepos[backup.Spec.BackupStorageName] = struct{}{}
 
-		p.addRepoToPGGlobal(backupStorage.Spec.VerifyTLS, repo.Name, backupStorages[repo.Name].Spec.ForcePathStyle, nil, db)
+		p.addRepoToPGGlobal(backupStorage.Spec.VerifyTLS, repo.Name, backupStorage.Spec.ForcePathStyle, nil, db)
 		err = updatePGIni(p.pgBackRestSecretIni, backupStoragesSecrets[backup.Spec.BackupStorageName], repo)
 		if err != nil {
 			return errors.Join(err, errors.New("failed to add backup storage credentials to PGBackrest secret data"))
@@ -246,7 +246,8 @@ func (p *pgReposReconciler) reconcileExistingSchedules(
 			// Keep track of backup storages which are already in use by a repo
 			p.backupStoragesInRepos[backupSchedule.BackupStorageName] = struct{}{}
 
-			p.addRepoToPGGlobal(backupStorages[repo.Name].Spec.VerifyTLS, repo.Name, backupStorages[repo.Name].Spec.ForcePathStyle, &backupSchedule.RetentionCopies, db)
+			bs := backupStorages[backupSchedule.BackupStorageName]
+			p.addRepoToPGGlobal(bs.Spec.VerifyTLS, repo.Name, bs.Spec.ForcePathStyle, &backupSchedule.RetentionCopies, db)
 			err := updatePGIni(p.pgBackRestSecretIni, backupStoragesSecrets[backupSchedule.BackupStorageName], repo)
 			if err != nil {
 				return errors.Join(err, errors.New("failed to add backup storage credentials to PGBackrest secret data"))
@@ -296,8 +297,8 @@ func (p *pgReposReconciler) reconcileRepos(
 				// Keep track of backup storages which are already in use by a repo
 				p.backupStoragesInRepos[backupSchedule.BackupStorageName] = struct{}{}
 
-				p.addRepoToPGGlobal(backupStorages[repo.Name].Spec.VerifyTLS,
-					repo.Name, backupStorages[repo.Name].Spec.ForcePathStyle,
+				p.addRepoToPGGlobal(backupStorages[backupSchedule.BackupStorageName].Spec.VerifyTLS,
+					repo.Name, backupStorages[backupSchedule.BackupStorageName].Spec.ForcePathStyle,
 					&backupSchedule.RetentionCopies, db,
 				)
 				err := updatePGIni(p.pgBackRestSecretIni, backupStoragesSecrets[backupSchedule.BackupStorageName], repo)
@@ -385,7 +386,7 @@ func (p *pgReposReconciler) addNewSchedules( //nolint:gocognit
 		// Keep track of backup storages which are already in use by a repo
 		p.backupStoragesInRepos[backupSchedule.BackupStorageName] = struct{}{}
 
-		p.addRepoToPGGlobal(backupStorage.Spec.VerifyTLS, repo.Name, backupStorages[repo.Name].Spec.ForcePathStyle, &backupSchedule.RetentionCopies, db)
+		p.addRepoToPGGlobal(backupStorage.Spec.VerifyTLS, repo.Name, backupStorage.Spec.ForcePathStyle, &backupSchedule.RetentionCopies, db)
 		err = updatePGIni(p.pgBackRestSecretIni, backupStoragesSecrets[backupSchedule.BackupStorageName], repo)
 		if err != nil {
 			return errors.Join(err, errors.New("failed to add backup storage credentials to PGBackrest secret data"))

--- a/internal/controller/everest/providers/pg/pg_test.go
+++ b/internal/controller/everest/providers/pg/pg_test.go
@@ -6482,3 +6482,212 @@ func TestReconcilePGBackRestReposVerifyTLSDisabled(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "n", global["repo1-storage-verify-tls"])
 }
+
+func TestReconcilePGBackRestReposVerifyTLSUnset(t *testing.T) {
+	t.Parallel()
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{Spec: everestv1alpha1.DatabaseClusterBackupSpec{BackupStorageName: "backupStorage1"}},
+	}
+
+	_, global, _, err := reconcilePGBackRestRepos(
+		[]crunchyv1beta1.PGBackRestRepo{},
+		[]everestv1alpha1.BackupSchedule{},
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
+			},
+		},
+		false,
+	)
+	require.NoError(t, err)
+	assert.NotContains(t, global, "repo1-storage-verify-tls")
+}
+
+func TestReconcilePGBackRestReposForcePathStyle(t *testing.T) {
+	t.Parallel()
+
+	db := &everestv1alpha1.DatabaseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", UID: "123"},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("key"),
+				"AWS_SECRET_ACCESS_KEY": []byte("secret"),
+			},
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{Spec: everestv1alpha1.DatabaseClusterBackupSpec{BackupStorageName: "backupStorage1"}},
+	}
+
+	t.Run("forcePathStyle=true", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:           everestv1alpha1.BackupStorageTypeS3,
+					Bucket:         "bucket1",
+					Region:         "region1",
+					ForcePathStyle: pointer.ToBool(true),
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			[]crunchyv1beta1.PGBackRestRepo{},
+			[]everestv1alpha1.BackupSchedule{},
+			testBackupRequests,
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "path", global["repo1-s3-uri-style"])
+	})
+
+	t.Run("forcePathStyle=false", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:           everestv1alpha1.BackupStorageTypeS3,
+					Bucket:         "bucket1",
+					Region:         "region1",
+					ForcePathStyle: pointer.ToBool(false),
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			[]crunchyv1beta1.PGBackRestRepo{},
+			[]everestv1alpha1.BackupSchedule{},
+			testBackupRequests,
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.NotContains(t, global, "repo1-s3-uri-style")
+	})
+}
+
+func TestReconcilePGBackRestReposVerifyTLSSchedulePath(t *testing.T) {
+	t.Parallel()
+
+	db := &everestv1alpha1.DatabaseCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", UID: "123"},
+	}
+	testSchedule := "0 0 * * *"
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          testSchedule,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("key"),
+				"AWS_SECRET_ACCESS_KEY": []byte("secret"),
+			},
+		},
+	}
+
+	t.Run("verifyTLS=true via addNewSchedules", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:      everestv1alpha1.BackupStorageTypeS3,
+					Bucket:    "bucket1",
+					Region:    "region1",
+					VerifyTLS: pointer.ToBool(true),
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			[]crunchyv1beta1.PGBackRestRepo{},
+			testBackupSchedules,
+			[]everestv1alpha1.DatabaseClusterBackup{},
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.NotContains(t, global, "repo1-storage-verify-tls")
+	})
+
+	t.Run("verifyTLS=true via reconcileExistingSchedules", func(t *testing.T) {
+		t.Parallel()
+		existingRepos := []crunchyv1beta1.PGBackRestRepo{
+			{
+				Name: "repo1",
+				S3: &crunchyv1beta1.RepoS3{
+					Bucket:   "bucket1",
+					Region:   "region1",
+					Endpoint: "endpoint1",
+				},
+				BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+					Full: &testSchedule,
+				},
+			},
+		}
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backupStorage1",
+					Namespace: db.Namespace,
+				},
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:        everestv1alpha1.BackupStorageTypeS3,
+					Bucket:      "bucket1",
+					Region:      "region1",
+					EndpointURL: "endpoint1",
+					VerifyTLS:   pointer.ToBool(true),
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			existingRepos,
+			testBackupSchedules,
+			[]everestv1alpha1.DatabaseClusterBackup{},
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.NotContains(t, global, "repo1-storage-verify-tls")
+	})
+}

--- a/internal/controller/everest/providers/pg/pg_test.go
+++ b/internal/controller/everest/providers/pg/pg_test.go
@@ -6395,473 +6395,90 @@ func pvcVolumeAndEngineStorage() (*crunchyv1beta1.RepoPVC, everestv1alpha1.Stora
 	}, testEngineStorage
 }
 
-func TestVerifyTLS_ReconcileBackups(t *testing.T) {
+func TestReconcilePGBackRestReposVerifyTLSEnabled(t *testing.T) {
 	t.Parallel()
-
-	db := &everestv1alpha1.DatabaseCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-			UID:  "123",
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+		"backupStorage1": {
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+				VerifyTLS:   pointer.ToBool(true),
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
+			},
 		},
 	}
 	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
 		{Spec: everestv1alpha1.DatabaseClusterBackupSpec{BackupStorageName: "backupStorage1"}},
 	}
-	testBackupStoragesSecrets := map[string]*corev1.Secret{
-		"backupStorage1": {
-			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("key"),
-				"AWS_SECRET_ACCESS_KEY": []byte("secret"),
+
+	_, global, _, err := reconcilePGBackRestRepos(
+		[]crunchyv1beta1.PGBackRestRepo{},
+		[]everestv1alpha1.BackupSchedule{},
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
 			},
 		},
-	}
-
-	t.Run("verifyTLS=true", func(t *testing.T) {
-		t.Parallel()
-		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-			"backupStorage1": {
-				Spec: everestv1alpha1.BackupStorageSpec{
-					Type:      everestv1alpha1.BackupStorageTypeS3,
-					Bucket:    "bucket1",
-					Region:    "region1",
-					VerifyTLS: pointer.ToBool(true),
-				},
-			},
-		}
-		_, global, _, err := reconcilePGBackRestRepos(
-			[]crunchyv1beta1.PGBackRestRepo{},
-			[]everestv1alpha1.BackupSchedule{},
-			testBackupRequests,
-			testBackupStorages,
-			testBackupStoragesSecrets,
-			testEngineStorage,
-			db,
-			false,
-		)
-		require.NoError(t, err)
-		assert.NotContains(t, global, "repo1-storage-verify-tls")
-	})
-
-	t.Run("verifyTLS=false", func(t *testing.T) {
-		t.Parallel()
-		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-			"backupStorage1": {
-				Spec: everestv1alpha1.BackupStorageSpec{
-					Type:      everestv1alpha1.BackupStorageTypeS3,
-					Bucket:    "bucket1",
-					Region:    "region1",
-					VerifyTLS: pointer.ToBool(false),
-				},
-			},
-		}
-		_, global, _, err := reconcilePGBackRestRepos(
-			[]crunchyv1beta1.PGBackRestRepo{},
-			[]everestv1alpha1.BackupSchedule{},
-			testBackupRequests,
-			testBackupStorages,
-			testBackupStoragesSecrets,
-			testEngineStorage,
-			db,
-			false,
-		)
-		require.NoError(t, err)
-		assert.Equal(t, "n", global["repo1-storage-verify-tls"])
-	})
-
-	t.Run("verifyTLS=nil", func(t *testing.T) {
-		t.Parallel()
-		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-			"backupStorage1": {
-				Spec: everestv1alpha1.BackupStorageSpec{
-					Type:   everestv1alpha1.BackupStorageTypeS3,
-					Bucket: "bucket1",
-					Region: "region1",
-				},
-			},
-		}
-		_, global, _, err := reconcilePGBackRestRepos(
-			[]crunchyv1beta1.PGBackRestRepo{},
-			[]everestv1alpha1.BackupSchedule{},
-			testBackupRequests,
-			testBackupStorages,
-			testBackupStoragesSecrets,
-			testEngineStorage,
-			db,
-			false,
-		)
-		require.NoError(t, err)
-		assert.NotContains(t, global, "repo1-storage-verify-tls")
-	})
+		false,
+	)
+	require.NoError(t, err)
+	assert.NotContains(t, global, "repo1-storage-verify-tls")
 }
 
-func TestVerifyTLS_AddNewSchedules(t *testing.T) {
+func TestReconcilePGBackRestReposVerifyTLSDisabled(t *testing.T) {
 	t.Parallel()
-
-	db := &everestv1alpha1.DatabaseCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-			UID:  "123",
-		},
-	}
-	testSchedule := "0 0 * * *"
-	testBackupSchedules := []everestv1alpha1.BackupSchedule{
-		{
-			Enabled:           true,
-			Name:              "schedule1",
-			Schedule:          testSchedule,
-			BackupStorageName: "backupStorage1",
-		},
-	}
-	testBackupStoragesSecrets := map[string]*corev1.Secret{
+	testBackupStorages := map[string]everestv1alpha1.BackupStorage{
 		"backupStorage1": {
-			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("key"),
-				"AWS_SECRET_ACCESS_KEY": []byte("secret"),
-			},
-		},
-	}
-
-	t.Run("verifyTLS=true", func(t *testing.T) {
-		t.Parallel()
-		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-			"backupStorage1": {
-				Spec: everestv1alpha1.BackupStorageSpec{
-					Type:      everestv1alpha1.BackupStorageTypeS3,
-					Bucket:    "bucket1",
-					Region:    "region1",
-					VerifyTLS: pointer.ToBool(true),
-				},
-			},
-		}
-		_, global, _, err := reconcilePGBackRestRepos(
-			[]crunchyv1beta1.PGBackRestRepo{},
-			testBackupSchedules,
-			[]everestv1alpha1.DatabaseClusterBackup{},
-			testBackupStorages,
-			testBackupStoragesSecrets,
-			testEngineStorage,
-			db,
-			false,
-		)
-		require.NoError(t, err)
-		assert.NotContains(t, global, "repo1-storage-verify-tls")
-	})
-
-	t.Run("verifyTLS=false", func(t *testing.T) {
-		t.Parallel()
-		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-			"backupStorage1": {
-				Spec: everestv1alpha1.BackupStorageSpec{
-					Type:      everestv1alpha1.BackupStorageTypeS3,
-					Bucket:    "bucket1",
-					Region:    "region1",
-					VerifyTLS: pointer.ToBool(false),
-				},
-			},
-		}
-		_, global, _, err := reconcilePGBackRestRepos(
-			[]crunchyv1beta1.PGBackRestRepo{},
-			testBackupSchedules,
-			[]everestv1alpha1.DatabaseClusterBackup{},
-			testBackupStorages,
-			testBackupStoragesSecrets,
-			testEngineStorage,
-			db,
-			false,
-		)
-		require.NoError(t, err)
-		assert.Equal(t, "n", global["repo1-storage-verify-tls"])
-	})
-
-	t.Run("verifyTLS=nil", func(t *testing.T) {
-		t.Parallel()
-		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-			"backupStorage1": {
-				Spec: everestv1alpha1.BackupStorageSpec{
-					Type:   everestv1alpha1.BackupStorageTypeS3,
-					Bucket: "bucket1",
-					Region: "region1",
-				},
-			},
-		}
-		_, global, _, err := reconcilePGBackRestRepos(
-			[]crunchyv1beta1.PGBackRestRepo{},
-			testBackupSchedules,
-			[]everestv1alpha1.DatabaseClusterBackup{},
-			testBackupStorages,
-			testBackupStoragesSecrets,
-			testEngineStorage,
-			db,
-			false,
-		)
-		require.NoError(t, err)
-		assert.NotContains(t, global, "repo1-storage-verify-tls")
-	})
-}
-
-func TestVerifyTLS_ReconcileExistingSchedules(t *testing.T) {
-	t.Parallel()
-
-	db := &everestv1alpha1.DatabaseCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-			UID:  "123",
-		},
-	}
-	testSchedule := "0 0 * * *"
-	testBackupSchedules := []everestv1alpha1.BackupSchedule{
-		{
-			Enabled:           true,
-			Name:              "schedule1",
-			Schedule:          testSchedule,
-			BackupStorageName: "backupStorage1",
-		},
-	}
-	testRepos := []crunchyv1beta1.PGBackRestRepo{
-		{
-			Name: "repo1",
-			S3: &crunchyv1beta1.RepoS3{
-				Bucket:   "bucket1",
-				Region:   "region1",
-				Endpoint: "endpoint1",
-			},
-			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
-				Full: &testSchedule,
+			Spec: everestv1alpha1.BackupStorageSpec{
+				Type:        everestv1alpha1.BackupStorageTypeS3,
+				Bucket:      "bucket1",
+				Region:      "region1",
+				EndpointURL: "endpoint1",
+				VerifyTLS:   pointer.ToBool(false),
 			},
 		},
 	}
 	testBackupStoragesSecrets := map[string]*corev1.Secret{
 		"backupStorage1": {
 			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("key"),
-				"AWS_SECRET_ACCESS_KEY": []byte("secret"),
+				"AWS_ACCESS_KEY_ID":     []byte("SomeAccessKeyID"),
+				"AWS_SECRET_ACCESS_KEY": []byte("SomeSecretAccessKey"),
 			},
 		},
 	}
-
-	t.Run("verifyTLS=true", func(t *testing.T) {
-		t.Parallel()
-		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-			"backupStorage1": {
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "backupStorage1",
-					Namespace: db.Namespace,
-				},
-				Spec: everestv1alpha1.BackupStorageSpec{
-					Type:        everestv1alpha1.BackupStorageTypeS3,
-					Bucket:      "bucket1",
-					Region:      "region1",
-					EndpointURL: "endpoint1",
-					VerifyTLS:   pointer.ToBool(true),
-				},
-			},
-		}
-		_, global, _, err := reconcilePGBackRestRepos(
-			testRepos,
-			testBackupSchedules,
-			[]everestv1alpha1.DatabaseClusterBackup{},
-			testBackupStorages,
-			testBackupStoragesSecrets,
-			testEngineStorage,
-			db,
-			false,
-		)
-		require.NoError(t, err)
-		assert.NotContains(t, global, "repo1-storage-verify-tls")
-	})
-
-	t.Run("verifyTLS=false", func(t *testing.T) {
-		t.Parallel()
-		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-			"backupStorage1": {
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "backupStorage1",
-					Namespace: db.Namespace,
-				},
-				Spec: everestv1alpha1.BackupStorageSpec{
-					Type:        everestv1alpha1.BackupStorageTypeS3,
-					Bucket:      "bucket1",
-					Region:      "region1",
-					EndpointURL: "endpoint1",
-					VerifyTLS:   pointer.ToBool(false),
-				},
-			},
-		}
-		_, global, _, err := reconcilePGBackRestRepos(
-			testRepos,
-			testBackupSchedules,
-			[]everestv1alpha1.DatabaseClusterBackup{},
-			testBackupStorages,
-			testBackupStoragesSecrets,
-			testEngineStorage,
-			db,
-			false,
-		)
-		require.NoError(t, err)
-		assert.Equal(t, "n", global["repo1-storage-verify-tls"])
-	})
-
-	t.Run("verifyTLS=nil", func(t *testing.T) {
-		t.Parallel()
-		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-			"backupStorage1": {
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "backupStorage1",
-					Namespace: db.Namespace,
-				},
-				Spec: everestv1alpha1.BackupStorageSpec{
-					Type:        everestv1alpha1.BackupStorageTypeS3,
-					Bucket:      "bucket1",
-					Region:      "region1",
-					EndpointURL: "endpoint1",
-				},
-			},
-		}
-		_, global, _, err := reconcilePGBackRestRepos(
-			testRepos,
-			testBackupSchedules,
-			[]everestv1alpha1.DatabaseClusterBackup{},
-			testBackupStorages,
-			testBackupStoragesSecrets,
-			testEngineStorage,
-			db,
-			false,
-		)
-		require.NoError(t, err)
-		assert.NotContains(t, global, "repo1-storage-verify-tls")
-	})
-}
-
-func TestVerifyTLS_ReconcileRepos(t *testing.T) {
-	t.Parallel()
-
-	db := &everestv1alpha1.DatabaseCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-			UID:  "123",
-		},
-	}
-	oldSchedule := "0 0 * * *"
-	newSchedule := "0 1 * * *"
-	testBackupSchedules := []everestv1alpha1.BackupSchedule{
-		{
-			Enabled:           true,
-			Name:              "schedule1",
-			Schedule:          newSchedule,
-			BackupStorageName: "backupStorage1",
-		},
-	}
-	testRepos := []crunchyv1beta1.PGBackRestRepo{
-		{
-			Name: "repo1",
-			S3: &crunchyv1beta1.RepoS3{
-				Bucket:   "bucket1",
-				Region:   "region1",
-				Endpoint: "endpoint1",
-			},
-			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
-				Full: &oldSchedule,
-			},
-		},
-	}
-	testBackupStoragesSecrets := map[string]*corev1.Secret{
-		"backupStorage1": {
-			Data: map[string][]byte{
-				"AWS_ACCESS_KEY_ID":     []byte("key"),
-				"AWS_SECRET_ACCESS_KEY": []byte("secret"),
-			},
-		},
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{Spec: everestv1alpha1.DatabaseClusterBackupSpec{BackupStorageName: "backupStorage1"}},
 	}
 
-	t.Run("verifyTLS=true", func(t *testing.T) {
-		t.Parallel()
-		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-			"backupStorage1": {
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "backupStorage1",
-					Namespace: db.Namespace,
-				},
-				Spec: everestv1alpha1.BackupStorageSpec{
-					Type:        everestv1alpha1.BackupStorageTypeS3,
-					Bucket:      "bucket1",
-					Region:      "region1",
-					EndpointURL: "endpoint1",
-					VerifyTLS:   pointer.ToBool(true),
-				},
+	_, global, _, err := reconcilePGBackRestRepos(
+		[]crunchyv1beta1.PGBackRestRepo{},
+		[]everestv1alpha1.BackupSchedule{},
+		testBackupRequests,
+		testBackupStorages,
+		testBackupStoragesSecrets,
+		testEngineStorage,
+		&everestv1alpha1.DatabaseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				UID:  "123",
 			},
-		}
-		_, global, _, err := reconcilePGBackRestRepos(
-			testRepos,
-			testBackupSchedules,
-			[]everestv1alpha1.DatabaseClusterBackup{},
-			testBackupStorages,
-			testBackupStoragesSecrets,
-			testEngineStorage,
-			db,
-			false,
-		)
-		require.NoError(t, err)
-		assert.NotContains(t, global, "repo1-storage-verify-tls")
-	})
-
-	t.Run("verifyTLS=false", func(t *testing.T) {
-		t.Parallel()
-		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-			"backupStorage1": {
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "backupStorage1",
-					Namespace: db.Namespace,
-				},
-				Spec: everestv1alpha1.BackupStorageSpec{
-					Type:        everestv1alpha1.BackupStorageTypeS3,
-					Bucket:      "bucket1",
-					Region:      "region1",
-					EndpointURL: "endpoint1",
-					VerifyTLS:   pointer.ToBool(false),
-				},
-			},
-		}
-		_, global, _, err := reconcilePGBackRestRepos(
-			testRepos,
-			testBackupSchedules,
-			[]everestv1alpha1.DatabaseClusterBackup{},
-			testBackupStorages,
-			testBackupStoragesSecrets,
-			testEngineStorage,
-			db,
-			false,
-		)
-		require.NoError(t, err)
-		assert.Equal(t, "n", global["repo1-storage-verify-tls"])
-	})
-
-	t.Run("verifyTLS=nil", func(t *testing.T) {
-		t.Parallel()
-		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
-			"backupStorage1": {
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "backupStorage1",
-					Namespace: db.Namespace,
-				},
-				Spec: everestv1alpha1.BackupStorageSpec{
-					Type:        everestv1alpha1.BackupStorageTypeS3,
-					Bucket:      "bucket1",
-					Region:      "region1",
-					EndpointURL: "endpoint1",
-				},
-			},
-		}
-		_, global, _, err := reconcilePGBackRestRepos(
-			testRepos,
-			testBackupSchedules,
-			[]everestv1alpha1.DatabaseClusterBackup{},
-			testBackupStorages,
-			testBackupStoragesSecrets,
-			testEngineStorage,
-			db,
-			false,
-		)
-		require.NoError(t, err)
-		assert.NotContains(t, global, "repo1-storage-verify-tls")
-	})
+		},
+		false,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "n", global["repo1-storage-verify-tls"])
 }

--- a/internal/controller/everest/providers/pg/pg_test.go
+++ b/internal/controller/everest/providers/pg/pg_test.go
@@ -6394,3 +6394,474 @@ func pvcVolumeAndEngineStorage() (*crunchyv1beta1.RepoPVC, everestv1alpha1.Stora
 		},
 	}, testEngineStorage
 }
+
+func TestVerifyTLS_ReconcileBackups(t *testing.T) {
+	t.Parallel()
+
+	db := &everestv1alpha1.DatabaseCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+			UID:  "123",
+		},
+	}
+	testBackupRequests := []everestv1alpha1.DatabaseClusterBackup{
+		{Spec: everestv1alpha1.DatabaseClusterBackupSpec{BackupStorageName: "backupStorage1"}},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("key"),
+				"AWS_SECRET_ACCESS_KEY": []byte("secret"),
+			},
+		},
+	}
+
+	t.Run("verifyTLS=true", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:      everestv1alpha1.BackupStorageTypeS3,
+					Bucket:    "bucket1",
+					Region:    "region1",
+					VerifyTLS: pointer.ToBool(true),
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			[]crunchyv1beta1.PGBackRestRepo{},
+			[]everestv1alpha1.BackupSchedule{},
+			testBackupRequests,
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.NotContains(t, global, "repo1-storage-verify-tls")
+	})
+
+	t.Run("verifyTLS=false", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:      everestv1alpha1.BackupStorageTypeS3,
+					Bucket:    "bucket1",
+					Region:    "region1",
+					VerifyTLS: pointer.ToBool(false),
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			[]crunchyv1beta1.PGBackRestRepo{},
+			[]everestv1alpha1.BackupSchedule{},
+			testBackupRequests,
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "n", global["repo1-storage-verify-tls"])
+	})
+
+	t.Run("verifyTLS=nil", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:   everestv1alpha1.BackupStorageTypeS3,
+					Bucket: "bucket1",
+					Region: "region1",
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			[]crunchyv1beta1.PGBackRestRepo{},
+			[]everestv1alpha1.BackupSchedule{},
+			testBackupRequests,
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.NotContains(t, global, "repo1-storage-verify-tls")
+	})
+}
+
+func TestVerifyTLS_AddNewSchedules(t *testing.T) {
+	t.Parallel()
+
+	db := &everestv1alpha1.DatabaseCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+			UID:  "123",
+		},
+	}
+	testSchedule := "0 0 * * *"
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          testSchedule,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("key"),
+				"AWS_SECRET_ACCESS_KEY": []byte("secret"),
+			},
+		},
+	}
+
+	t.Run("verifyTLS=true", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:      everestv1alpha1.BackupStorageTypeS3,
+					Bucket:    "bucket1",
+					Region:    "region1",
+					VerifyTLS: pointer.ToBool(true),
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			[]crunchyv1beta1.PGBackRestRepo{},
+			testBackupSchedules,
+			[]everestv1alpha1.DatabaseClusterBackup{},
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.NotContains(t, global, "repo1-storage-verify-tls")
+	})
+
+	t.Run("verifyTLS=false", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:      everestv1alpha1.BackupStorageTypeS3,
+					Bucket:    "bucket1",
+					Region:    "region1",
+					VerifyTLS: pointer.ToBool(false),
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			[]crunchyv1beta1.PGBackRestRepo{},
+			testBackupSchedules,
+			[]everestv1alpha1.DatabaseClusterBackup{},
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "n", global["repo1-storage-verify-tls"])
+	})
+
+	t.Run("verifyTLS=nil", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:   everestv1alpha1.BackupStorageTypeS3,
+					Bucket: "bucket1",
+					Region: "region1",
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			[]crunchyv1beta1.PGBackRestRepo{},
+			testBackupSchedules,
+			[]everestv1alpha1.DatabaseClusterBackup{},
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.NotContains(t, global, "repo1-storage-verify-tls")
+	})
+}
+
+func TestVerifyTLS_ReconcileExistingSchedules(t *testing.T) {
+	t.Parallel()
+
+	db := &everestv1alpha1.DatabaseCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+			UID:  "123",
+		},
+	}
+	testSchedule := "0 0 * * *"
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          testSchedule,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &testSchedule,
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("key"),
+				"AWS_SECRET_ACCESS_KEY": []byte("secret"),
+			},
+		},
+	}
+
+	t.Run("verifyTLS=true", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backupStorage1",
+					Namespace: db.Namespace,
+				},
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:        everestv1alpha1.BackupStorageTypeS3,
+					Bucket:      "bucket1",
+					Region:      "region1",
+					EndpointURL: "endpoint1",
+					VerifyTLS:   pointer.ToBool(true),
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			testRepos,
+			testBackupSchedules,
+			[]everestv1alpha1.DatabaseClusterBackup{},
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.NotContains(t, global, "repo1-storage-verify-tls")
+	})
+
+	t.Run("verifyTLS=false", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backupStorage1",
+					Namespace: db.Namespace,
+				},
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:        everestv1alpha1.BackupStorageTypeS3,
+					Bucket:      "bucket1",
+					Region:      "region1",
+					EndpointURL: "endpoint1",
+					VerifyTLS:   pointer.ToBool(false),
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			testRepos,
+			testBackupSchedules,
+			[]everestv1alpha1.DatabaseClusterBackup{},
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "n", global["repo1-storage-verify-tls"])
+	})
+
+	t.Run("verifyTLS=nil", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backupStorage1",
+					Namespace: db.Namespace,
+				},
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:        everestv1alpha1.BackupStorageTypeS3,
+					Bucket:      "bucket1",
+					Region:      "region1",
+					EndpointURL: "endpoint1",
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			testRepos,
+			testBackupSchedules,
+			[]everestv1alpha1.DatabaseClusterBackup{},
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.NotContains(t, global, "repo1-storage-verify-tls")
+	})
+}
+
+func TestVerifyTLS_ReconcileRepos(t *testing.T) {
+	t.Parallel()
+
+	db := &everestv1alpha1.DatabaseCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+			UID:  "123",
+		},
+	}
+	oldSchedule := "0 0 * * *"
+	newSchedule := "0 1 * * *"
+	testBackupSchedules := []everestv1alpha1.BackupSchedule{
+		{
+			Enabled:           true,
+			Name:              "schedule1",
+			Schedule:          newSchedule,
+			BackupStorageName: "backupStorage1",
+		},
+	}
+	testRepos := []crunchyv1beta1.PGBackRestRepo{
+		{
+			Name: "repo1",
+			S3: &crunchyv1beta1.RepoS3{
+				Bucket:   "bucket1",
+				Region:   "region1",
+				Endpoint: "endpoint1",
+			},
+			BackupSchedules: &crunchyv1beta1.PGBackRestBackupSchedules{
+				Full: &oldSchedule,
+			},
+		},
+	}
+	testBackupStoragesSecrets := map[string]*corev1.Secret{
+		"backupStorage1": {
+			Data: map[string][]byte{
+				"AWS_ACCESS_KEY_ID":     []byte("key"),
+				"AWS_SECRET_ACCESS_KEY": []byte("secret"),
+			},
+		},
+	}
+
+	t.Run("verifyTLS=true", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backupStorage1",
+					Namespace: db.Namespace,
+				},
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:        everestv1alpha1.BackupStorageTypeS3,
+					Bucket:      "bucket1",
+					Region:      "region1",
+					EndpointURL: "endpoint1",
+					VerifyTLS:   pointer.ToBool(true),
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			testRepos,
+			testBackupSchedules,
+			[]everestv1alpha1.DatabaseClusterBackup{},
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.NotContains(t, global, "repo1-storage-verify-tls")
+	})
+
+	t.Run("verifyTLS=false", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backupStorage1",
+					Namespace: db.Namespace,
+				},
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:        everestv1alpha1.BackupStorageTypeS3,
+					Bucket:      "bucket1",
+					Region:      "region1",
+					EndpointURL: "endpoint1",
+					VerifyTLS:   pointer.ToBool(false),
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			testRepos,
+			testBackupSchedules,
+			[]everestv1alpha1.DatabaseClusterBackup{},
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "n", global["repo1-storage-verify-tls"])
+	})
+
+	t.Run("verifyTLS=nil", func(t *testing.T) {
+		t.Parallel()
+		testBackupStorages := map[string]everestv1alpha1.BackupStorage{
+			"backupStorage1": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backupStorage1",
+					Namespace: db.Namespace,
+				},
+				Spec: everestv1alpha1.BackupStorageSpec{
+					Type:        everestv1alpha1.BackupStorageTypeS3,
+					Bucket:      "bucket1",
+					Region:      "region1",
+					EndpointURL: "endpoint1",
+				},
+			},
+		}
+		_, global, _, err := reconcilePGBackRestRepos(
+			testRepos,
+			testBackupSchedules,
+			[]everestv1alpha1.DatabaseClusterBackup{},
+			testBackupStorages,
+			testBackupStoragesSecrets,
+			testEngineStorage,
+			db,
+			false,
+		)
+		require.NoError(t, err)
+		assert.NotContains(t, global, "repo1-storage-verify-tls")
+	})
+}

--- a/internal/controller/everest/providers/psmdb/applier.go
+++ b/internal/controller/everest/providers/psmdb/applier.go
@@ -639,7 +639,7 @@ func (p *applier) addBackupStoragesByRestores(
 					Region:                backupStorage.Spec.Region,
 					EndpointURL:           backupStorage.Spec.EndpointURL,
 					Prefix:                common.BackupStoragePrefix(database),
-					InsecureSkipTLSVerify: !pointer.Get(backupStorage.Spec.VerifyTLS),
+					InsecureSkipTLSVerify: backupStorage.Spec.VerifyTLS != nil && !*backupStorage.Spec.VerifyTLS,
 				},
 			}
 		}
@@ -697,7 +697,7 @@ func (p *applier) addBackupStoragesByDatabaseClusterBackups(
 					Region:                backupStorage.Spec.Region,
 					EndpointURL:           backupStorage.Spec.EndpointURL,
 					Prefix:                common.BackupStoragePrefix(database),
-					InsecureSkipTLSVerify: !pointer.Get(backupStorage.Spec.VerifyTLS),
+					InsecureSkipTLSVerify: backupStorage.Spec.VerifyTLS != nil && !*backupStorage.Spec.VerifyTLS,
 				},
 			}
 		}
@@ -753,7 +753,7 @@ func (p *applier) getBackupTasks(
 					Region:                backupStorage.Spec.Region,
 					EndpointURL:           backupStorage.Spec.EndpointURL,
 					Prefix:                common.BackupStoragePrefix(database),
-					InsecureSkipTLSVerify: !pointer.Get(backupStorage.Spec.VerifyTLS),
+					InsecureSkipTLSVerify: backupStorage.Spec.VerifyTLS != nil && !*backupStorage.Spec.VerifyTLS,
 				},
 			}
 		}


### PR DESCRIPTION
## DESCRIPTION

### Problem

PostgreSQL backups using pgBackRest were not picking up the configured `verifyTLS` and `forcePathStyle` settings from BackupStorage (Fixes #956)

### Cause

The backup storage settings were being looked up using the wrong key, so the configured values were never applied. There was also an issue with the `forcePathStyle` logic that caused it to behave opposite to what was configured

### Solution

Updated the lookup to use the correct backup storage name and fixed the `forcePathStyle` handling. Added unit tests to cover all affected reconciliation paths

### AI Model Disclosure

Used VS Code Copilot (Claude Opus 4.8) to understand the issue context and help generate a fix. Changes were self-reviewed manually and verified via:

```bash
go build ./...
make test
make static-check
````

## CHECKLIST

### Helm chart

* [ ] Is the helm chart updated with the new changes?

### Jira

* [ ] Is the Jira ticket created and referenced properly?

### Tests

* [ ] Is an Integration test/test case added for the new feature/change?
* [x] Are unit tests added where appropriate?