### PR TITLE
feat: implement TTL secret controller for orphaned secrets cleanup

### DIFF
--- a/bundle/manifests/everest-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/everest-operator.clusterserviceversion.yaml
@@ -90,7 +90,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-04-27T16:20:11Z"
+    createdAt: "2026-06-04T17:30:45Z"
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: everest-operator.v0.0.0

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -320,6 +320,13 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "BackupStorage")
 		os.Exit(1)
 	}
+	if err = (&controllers.SecretReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Secret")
+		os.Exit(1)
+	}
 	if err = (&controllers.MonitoringConfigReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),

--- a/internal/consts/annotations.go
+++ b/internal/consts/annotations.go
@@ -30,4 +30,6 @@ const (
 	ManagedByDataImportAnnotation = EverestAnnotationPrefix + "managed-by-data-import"
 	// ManagedByDataImportAnnotationValueTrue is the value for the ManagedByDataImportAnnotation to indicate that the resource is managed by data import.
 	ManagedByDataImportAnnotationValueTrue = "true"
+	// CleanupAfterAnnotation is the annotation used to indicate that a resource should be cleaned up after a certain time.
+	CleanupAfterAnnotation = EverestAnnotationPrefix + "cleanup-after"
 )

--- a/internal/controller/everest/backupstorage_controller.go
+++ b/internal/controller/everest/backupstorage_controller.go
@@ -109,6 +109,9 @@ func (r *BackupStorageReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if err = controllerutil.SetControllerReference(bs, bsSecret, r.Scheme); err != nil {
 			return ctrl.Result{}, err
 		}
+		if bsSecret.Annotations != nil {
+			delete(bsSecret.Annotations, consts.CleanupAfterAnnotation)
+		}
 		if err = r.Update(ctx, bsSecret); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/everest/secret_controller.go
+++ b/internal/controller/everest/secret_controller.go
@@ -1,0 +1,98 @@
+// everest-operator
+// Copyright (C) 2022 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package everest
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/percona/everest-operator/internal/consts"
+	"github.com/percona/everest-operator/internal/controller/everest/common"
+)
+
+// SecretReconciler reconciles a Secret object.
+type SecretReconciler struct {
+	client.Client
+
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;update;patch;delete
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, req.NamespacedName, secret); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			logger.Error(err, "unable to fetch Secret")
+		}
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Check if the Secret has the cleanup annotation
+	cleanupTimeStr, ok := secret.Annotations[consts.CleanupAfterAnnotation]
+	if !ok {
+		return ctrl.Result{}, nil
+	}
+
+	// If the Secret has an OwnerReference, it's not orphaned, no need to clean up
+	if controller := metav1.GetControllerOf(secret); controller != nil {
+		// Optionally we could strip the annotation here, but it's handled by BackupStorage controller
+		return ctrl.Result{}, nil
+	}
+
+	cleanupTime, err := time.Parse(time.RFC3339, cleanupTimeStr)
+	if err != nil {
+		logger.Error(err, "invalid cleanup time format, ignoring", "annotation", consts.CleanupAfterAnnotation, "value", cleanupTimeStr)
+		// Strip the invalid annotation so we don't keep failing
+		delete(secret.Annotations, consts.CleanupAfterAnnotation)
+		if updateErr := r.Update(ctx, secret); updateErr != nil {
+			return ctrl.Result{}, updateErr
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if time.Now().After(cleanupTime) {
+		logger.Info("Deleting orphaned Secret", "secret", secret.Name)
+		if err := r.Delete(ctx, secret); client.IgnoreNotFound(err) != nil {
+			logger.Error(err, "unable to delete orphaned Secret")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Requeue until the cleanup time
+	return ctrl.Result{RequeueAfter: time.Until(cleanupTime)}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("Secret").
+		For(&corev1.Secret{}).
+		WithEventFilter(common.DefaultNamespaceFilter).
+		Complete(r)
+}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**

When a `BackupStorage` Custom Resource fails to be created (e.g., due to an API error), the `Secret` containing the storage credentials that was just created gets left orphaned. Because there's no parent CR, it lacks an `OwnerReference` and Kubernetes native garbage collection ignores it.

**Related pull requests**

- https://github.com/openeverest/openeverest/pull/2333

closes: https://github.com/openeverest/openeverest/issues/2332

**Cause:**
We modified the API handler to apply a TTL annotation instead of doing fragile synchronous deletion on failure. However, the operator needed a mechanism to recognize this annotation and actually perform the asynchronous cleanup of these orphaned Secrets.

**Solution:**
Introduced a new `SecretReconciler` (`secret_controller.go`) to watch and actively delete orphaned Secrets that still carry the expired `everest.percona.com/cleanup-after` annotation. Updated `BackupStorageReconciler` to adopt Secrets by stripping this annotation upon successful CR creation.

**CHECKLIST**
---
**Helm chart**
- [ ] Is the [helm chart](https://github.com/percona/percona-helm-charts/tree/main/charts/everest) updated with the new changes? (if applicable)

**Jira**
- [x] Is the Jira ticket created and referenced properly?

**Tests**
- [x] Is an Integration test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?