### PR TITLE
ci: declare explicit token permissions for workflows

### DIFF
--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   auto-update-base:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-integration-tests.yaml
+++ b/.github/workflows/ci-integration-tests.yaml
@@ -13,6 +13,9 @@ env:
   GONOSUMDB: 'github.com/percona'
   GOPRIVATE: 'github.com/percona'
 
+permissions:
+  contents: read
+
 jobs:
   integration-test:
     name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ env:
   GONOSUMDB: 'github.com/percona'
   GOPRIVATE: 'github.com/percona'
 
+permissions:
+  contents: read
+
 jobs:
   golang-build:
     name: Build Go binary

--- a/.github/workflows/e2e-k3d.yaml
+++ b/.github/workflows/e2e-k3d.yaml
@@ -13,6 +13,9 @@ env:
   GONOSUMDB: 'github.com/percona'
   GOPRIVATE: 'github.com/percona'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-k3d-test:
     name: test

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,6 +9,9 @@ env:
   GONOSUMDB: 'github.com/percona'
   GOPRIVATE: 'github.com/percona'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-core-flows:
     name: Core tests

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -9,6 +9,9 @@ env:
   GONOSUMDB: 'github.com/percona'
   GOPRIVATE: 'github.com/percona'
 
+permissions:
+  contents: read
+
 jobs:
   code-formatting:
     name: Code formatting


### PR DESCRIPTION
## Why

None of these six workflows declares a `permissions:` block, so each inherits the org-level default for `GITHUB_TOKEN`. That default was recently changed to **read repository contents**, so nothing is broken today — but a workflow that doesn't state its needs silently tracks whatever the org setting happens to be, and there's no review signal when that changes.

## Changes

All six get `contents: read`, which is what each actually uses:

| Workflow | Notes |
|---|---|
| `ci.yml` | passes `GITHUB_TOKEN` to `make`, used for module fetches (read) |
| `ci-integration-tests.yaml` | same, reusable workflow |
| `e2e-k3d.yaml` | same, reusable workflow |
| `e2e.yaml` | authenticates to AWS via its own secrets, not `GITHUB_TOKEN` |
| `static-checks.yml` | lint only |
| `auto-update-base.yaml` | uses `ROBOT_TOKEN` (a PAT) for its API calls, not `GITHUB_TOKEN` |

For the two reusable workflows (`workflow_call`), the block caps what their jobs can receive rather than granting anything — callers still can't hand them more than they hold.

## Separate follow-up: `auto-update-base.yaml`

That workflow uses `ROBOT_TOKEN` for `actions/github-script`, but the script only operates on `context.repo` — listing and updating PRs in **this** repository. `GITHUB_TOKEN` with `pull-requests: write` would cover the API calls.

The one thing to confirm first: events triggered by `GITHUB_TOKEN` don't start new workflow runs. If the point of changing a PR's base is to re-trigger its checks, the PAT is load-bearing and should stay. Worth checking before swapping.
